### PR TITLE
Fix #134 Grunt aggressively minifies HTML

### DIFF
--- a/static/widget/sandbox/gruntfile.coffee
+++ b/static/widget/sandbox/gruntfile.coffee
@@ -170,7 +170,6 @@ module.exports = (grunt) ->
 		htmlmin:
 			options:
 				removeComments    : true
-				collapseWhitespace: true
 			build:
 				files:
 					'temp/player.html': 'temp/player.html'


### PR DESCRIPTION
Removed collapseWhitespace from the Grunt config, which is off by
default. This option crunches out whitespace in the text nodes, which is
dangerous and led to this issue.

Without this option set, we still get benefits from minification, but a
few minor spaces are left within the lines.
