### PR TITLE
Fix #125: Use only selected image

### DIFF
--- a/public/assets/js/materia.page.media-import.js
+++ b/public/assets/js/materia.page.media-import.js
@@ -50,8 +50,8 @@ $(document).ready(function() {
 
 		var index = $('#question-table').dataTable().fnGetPosition( this );
 
-		if(selected) selectedAssets.push(data[index]);
-		else selectedAssets.splice( selectedAssets.indexOf( data[index] ), 1);
+		selectedAssets = [data[index]]
+
 	});
 
 	$('#submit-button').click( function(e) {


### PR DESCRIPTION
I'm not 100% sure what the implications are for the media import, but it
appears that only radios will ever be used in this JS, and thus the
array should only contain that one element. Prior to this commit, every
radio change resulted in an array push, and thus #125 would occur, where
the first radio selection would be passed to the creator, and the
intended one would be the last in the array.
