### PR TITLE
Apply no-cache header to widget pages

### DIFF
--- a/fuel/app/classes/controller/widgets.php
+++ b/fuel/app/classes/controller/widgets.php
@@ -48,6 +48,9 @@ class Controller_Widgets extends Controller
 			$response = Response::forge(Theme::instance()->render());
 		}
 
+		// prevent caching the widget page, since the __play_id is hard coded into the page
+		$response->set_header('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate');
+
 		return parent::after($response);
 	}
 


### PR DESCRIPTION
Needs review about whether or not this is a good idea, and if it's the right way to do this. But it does prevent a lot of issues with the play id being reused
