### PR TITLE
Fixes issue where Grunt could not package

### DIFF
--- a/static/sandbox/gruntfile.coffee
+++ b/static/sandbox/gruntfile.coffee
@@ -223,7 +223,10 @@ module.exports = (grunt) ->
 		clean:
 			pre: ["#{widget}/"]
 			post: ['temp/']
-			package: ["#{output}/#{widget}.zip"]
+			package:
+				src: ["#{output}/#{widget}.zip"]
+				options:
+					force: true
 
 	# Load Grunt Plugins.
 	require('load-grunt-tasks')(grunt)


### PR DESCRIPTION
Because of the symlinks, grunt does not recognize the package src as the
current working directory and as such blocks the command for safety
purposes. This overrides that.
