### PR TITLE
Add ability for Grunt to install the widget

### DIFF
--- a/static/sandbox/gruntfile.coffee
+++ b/static/sandbox/gruntfile.coffee
@@ -63,6 +63,10 @@ module.exports = (grunt) ->
 		'clean:package'
 	]
 
+	installTasks = [
+		'exec'
+	]
+
 	if grunt.option('minify-assets') != false
 		tasksToRun = compileTasks.concat minifyTasks.concat endTasks
 	else
@@ -225,6 +229,11 @@ module.exports = (grunt) ->
 			post: ['temp/']
 			package: ["#{output}/#{widget}.zip"]
 
+		exec:
+			install:
+				cmd: "php oil r widget:install static/sandbox/source/#{widget}/_output/#{widget}.wigt -f -u"
+				cwd: "../../"
+
 	# Load Grunt Plugins.
 	require('load-grunt-tasks')(grunt)
 
@@ -244,6 +253,11 @@ module.exports = (grunt) ->
 		grunt.log.writeln "output: #{output}"
 		grunt.task.run tasksToRun.concat packageTasks
 
+	grunt.registerTask 'install', ->
+		grunt.log.writeln "output: #{output}"
+		tasksToRun = tasksToRun.concat packageTasks.concat installTasks
+		grunt.task.run tasksToRun
+
 	showDocs = ->
 		grunt.log.writeln '''
 			Mako Grunt helps you develop and package HTML widgets for the Materia Platform.
@@ -253,6 +267,7 @@ module.exports = (grunt) ->
 				grunt sandbox                  Builds widget for Materia Platform Sandbox.
 				grunt watch                    Watches source files for changes and automatically runs sandbox.
 				grunt package                  Builds and packages widget for instillation into Materia.
+				grunt install                  Installs the widget into Materia for testing scoring and creating 
 
 			Required:
 				--widget=widgetdir             Widget name (matching directory inside static/widget/sandbox/source).

--- a/static/sandbox/package.json
+++ b/static/sandbox/package.json
@@ -19,5 +19,8 @@
     "grunt-contrib-less": "~0.8.2",
     "grunt-contrib-compress": "~0.5.2",
     "grunt-replace": "~0.7.7"
+  },
+  "dependencies": {
+    "grunt-exec": "~0.4.5"
   }
 }


### PR DESCRIPTION
Not sure if this is desirable or not, but it makes it a lot easier to test scoring and creating when the widget can be installed directly through grunt, instead of having to maintain a shell in the root directory
