### PR TITLE
When upgrading, use the previous catalog visibility

### DIFF
--- a/fuel/packages/materia/tasks/widget.php
+++ b/fuel/packages/materia/tasks/widget.php
@@ -749,6 +749,8 @@ class Widget  extends \Basetask
 		$existing_widget = new \Materia\Widget();
 		$existing_widget->get($widget_id);
 
+		$params['in_catalog'] = $existing_widget->in_catalog;
+
 		if ($existing_widget->id !== $widget_id)
 		{
 			\Cli::write('Not upgrading since existing Widget not found: '.$widget_id, 'red');


### PR DESCRIPTION
Is this how we wanted it implemented? The overall problem was that upgrading existing widgets could make them visible again when we manually hid them. This will fix that problem, at the cost that upgrading a widget from hidden to visible will have to be done manually.

Fix #181 
