### PR TITLE
changes widget edit url to be the same for editing and saved new widgets

### DIFF
--- a/src/coffee/controllers/ctrl-selectedwidget.coffee
+++ b/src/coffee/controllers/ctrl-selectedwidget.coffee
@@ -143,7 +143,7 @@ app.controller 'SelectedWidgetController', ($scope, $q, widgetSrv,selectedWidget
 		$scope.editable = ($scope.accessLevel > 0 and parseInt($scope.selectedWidget.widget.is_editable) is 1)
 
 		if $scope.editable
-			$scope.edit =  "edit/#{$scope.selectedWidget.id}/#{$scope.selectedWidget.clean_name}"
+			$scope.edit = "widgets/#{$scope.selectedWidget.widget.dir}create\##{$scope.selectedWidget.id}"
 		else
 			$scope.edit = "#"
 


### PR DESCRIPTION
The angular creator js didnt' handle edit links coming in from my widgets.

This changes them to use the same url that you get when saving a new widget, simplifying our urls, tests, and code.
