### PR TITLE
Prevent starting a new attempt outside of an LTI widget

### DIFF
--- a/fuel/app/classes/controller/scores.php
+++ b/fuel/app/classes/controller/scores.php
@@ -52,6 +52,12 @@ class Controller_Scores extends Controller
 		// TODO: remove ngmodal, jquery, convert author to something else, materia is a mess
 		Js::push_group(['angular', 'ng_modal', 'jquery', 'materia', 'author', 'student', 'labjs']);
 
+		$lti_token = \Input::get('ltitoken', false);
+		if ($lti_token)
+		{
+			Js::push_inline('var __LTI_TOKEN = "'.$lti_token.'";');
+		}
+
 		$this->theme->get_template()
 			->set('title', 'Score Results')
 			->set('page_type', 'scores');
@@ -71,7 +77,6 @@ class Controller_Scores extends Controller
 
 		// TODO: remove ngmodal, jquery, convert author to something else, materia is a mess
 		Js::push_group(['angular', 'ng_modal', 'jquery', 'materia', 'author', 'student']);
-
 
 		$lti_token = \Input::get('ltitoken', false);
 		if ($lti_token)

--- a/src/coffee/controllers/ctrl-scores.coffee
+++ b/src/coffee/controllers/ctrl-scores.coffee
@@ -98,7 +98,8 @@ app.controller 'scorePageController', ($scope, widgetSrv, scoreSrv) ->
 			# The Materia sendoff link requires currentAttempt to be set, so it's here instead of displayWidgetInstance
 			if isEmbedded
 				prefix = '/scores/'
-				$scope.moreInfoLink = prefix+widgetInstance.id+'#attempt-'+currentAttempt
+				token = if __LTI_TOKEN? then '?ltitoken=' + __LTI_TOKEN else ''
+				$scope.moreInfoLink = prefix + widgetInstance.id + token + '#attempt-' + currentAttempt
 
 			# display existing data or get more from the server
 			if details[$scope.attempts.length - currentAttempt]?
@@ -124,6 +125,14 @@ app.controller 'scorePageController', ($scope, widgetSrv, scoreSrv) ->
 				widget.href += '?ltitoken=' + __LTI_TOKEN
 		else
 			# if there are no attempts left, hide play again
+			hidePlayAgain = true
+
+		# If we have an LTI Token BUT this is not an embedded score page then we want to hide the play again button.
+		# That way the user will have to return to the embedded instance of Materia to continue playing, preventing
+		# issues with losing the LTI connection (as well as preventing duplicate page views of the same widget causing
+		# confusion). If we don't do this then more logic will need to be added to handle passing the ltitoken around
+		# and showing the proper scores page.
+		if __LTI_TOKEN? and !isEmbedded
 			hidePlayAgain = true
 
 		# Modify display of several elements after HTML is outputted


### PR DESCRIPTION
- Passes ltitoken to the normal (non-embedded) scores page
- Now hides play again button on the normal (non-embedded) scores page when an ltitoken exists
- Result of this change: Clicking on the more info link on the embedded scores page prevents starting a new game in the new window.
