### PR TITLE
Render header on 404 pages

### DIFF
--- a/fuel/app/classes/controller/site.php
+++ b/fuel/app/classes/controller/site.php
@@ -37,7 +37,7 @@ class Controller_Site extends Controller
 		// If no response object was returned by the action,
 		if (empty($response) or ! $response instanceof Response)
 		{
-			$this->setupHeader();
+			$this->setup_header();
 			$response = Response::forge(Theme::instance()->render());
 		}
 
@@ -108,7 +108,7 @@ class Controller_Site extends Controller
 
 		Log::warning("404 URL: ". Uri::main());
 
-		$this->setupHeader();
+		$this->setup_header();
 
 		$response = \Response::forge(\Theme::instance()->render(), 404);
 


### PR DESCRIPTION
Previous update to this code added 404s, but it removed the header. I
reworked the code in this class to get the header to render smoothly on
all the pages while using as much code as possible.

Fixes #306
