### PR TITLE
Fix 404 on widget detail pages

### DIFF
--- a/src/coffee/controllers/ctrl-widget-details.coffee
+++ b/src/coffee/controllers/ctrl-widget-details.coffee
@@ -2,7 +2,7 @@ app = angular.module 'materia'
 app.controller 'widgetDetailsController', ($scope, widgetSrv) ->
 
 	$scope.widget =
-		icon: "/assets/img/default/default-icon-275.png"
+		icon: "/themes/default/assets/img/default/default-icon-275.png"
 	$scope.goback =
 		text: "Go back to the widget catalog"
 		url: "/widgets"


### PR DESCRIPTION
Fixes #383 404 on widget detail pages for default icon
