### PR TITLE
Don't retain old values when copying widgets

### DIFF
--- a/public/themes/default/partials/my_widgets.php
+++ b/public/themes/default/partials/my_widgets.php
@@ -162,7 +162,7 @@
 			<modal-dialog class="copy" show="show.copyModal" dialog-title="Make a Copy:" width="620px" height="220px">
 				<div class="container">
 					<span class="input_label">New Title:</span>
-					<input class="newtitle" type="text" ng-model="$parent.$parent.copy_title" placeholder="New Widget Title" />
+					<input class="newtitle" type="text" ng-model="selected.copy_title" placeholder="New Widget Title" />
 					<span class="copy_error">Please enter a valid widget title.</span>
 					<a class="cancel_button" href="javascript:;" ng-click="hideModal()">Cancel</a>
 					<a class="action_button green copy_button" href="javascript:;" ng-click="copyWidget()">Copy</a>

--- a/src/coffee/controllers/ctrl-my-widgets.coffee
+++ b/src/coffee/controllers/ctrl-my-widgets.coffee
@@ -135,7 +135,7 @@ app.controller 'MyWidgetsController', ($scope, $q, $window, widgetSrv, userServ,
 		$scope.perms.error = false
 
 		$scope.selected.preview = "preview/#{$scope.selected.widget.id}/#{$scope.selected.widget.clean_name}"
-		$scope.copy_title =  "#{$scope.selected.widget.name} copy"
+		$scope.selected.copy_title =  "#{$scope.selected.widget.name} copy"
 		$scope.selected.widget.iconbig = Materia.Image.iconUrl $scope.selected.widget.widget.dir, 275
 
 	# Second half of populateDisplay

--- a/src/coffee/controllers/ctrl-selectedwidget.coffee
+++ b/src/coffee/controllers/ctrl-selectedwidget.coffee
@@ -21,7 +21,7 @@ app.controller 'SelectedWidgetController', ($scope, $q, widgetSrv,selectedWidget
 		Materia.MyWidgets.Csv.buildPopup()
 
 	$scope.copyWidget = ->
-		Materia.MyWidgets.Tasks.copyWidget $scope.selected.widget.id, $scope.copy_title, (inst_id) ->
+		Materia.MyWidgets.Tasks.copyWidget $scope.selected.widget.id, $scope.selected.copy_title, (inst_id) ->
 			$scope.show.copyModal = false
 			widgetSrv.addWidget(inst_id)
 			$scope.$apply()


### PR DESCRIPTION
Fixes #396 My Widgets - copy widget dialog retains old values
