### PR TITLE
Update the scope with a stale state when perms are loading

### DIFF
--- a/public/themes/default/partials/my_widgets.php
+++ b/public/themes/default/partials/my_widgets.php
@@ -206,7 +206,7 @@
 							</li>
 						</ul>
 						<ul class="options">
-							<li class="share"><div class="link" ng-click="showCollaboration()">Collaborate{{ collaborateCount }}</div></li>
+							<li class="share"><div class="link" ng-click="showCollaboration()" ng-class="{'disabled' : perms.stale}">Collaborate{{ collaborateCount }}</div></li>
 							<li class="copy" ng-class="{'disabled' : selected.accessLevel == 0}"><div class="link" id="copy_widget_link" ng-class="{'disabled' : selected.accessLevel == 0}" ng-click="showCopyDialog()">Make a Copy</div></li>
 							<li class="delete" ng-class="{'disabled' : selected.accessLevel == 0}"><div class="link" id="delete_widget_link" ng-class="{'disabled' : selected.accessLevel == 0}" ng-click="showDelete()">Delete</div></li>
 						</ul>

--- a/src/coffee/controllers/ctrl-my-widgets.coffee
+++ b/src/coffee/controllers/ctrl-my-widgets.coffee
@@ -79,6 +79,8 @@ app.controller 'MyWidgetsController', ($scope, $q, $window, widgetSrv, userServ,
 	# This doesn't actually "set" the widget
 	# It ensures required scope objects have been acquired before kicking off the display
 	setSelectedWidget = ->
+		$scope.perms.stale = true
+
 		populateDisplay()
 
 		currentId = $scope.selected.widget.id

--- a/src/coffee/controllers/ctrl-selectedwidget.coffee
+++ b/src/coffee/controllers/ctrl-selectedwidget.coffee
@@ -69,6 +69,8 @@ app.controller 'SelectedWidgetController', ($scope, $q, widgetSrv,selectedWidget
 		user_ids = []
 		user_ids.push(user) for user of $scope.perms.widget
 
+		return if user_ids.length < 1 or $scope.perms.stale
+
 		$scope.perms.collaborators = []
 
 		Materia.Coms.Json.send 'user_get', [user_ids], (users) ->


### PR DESCRIPTION
Fixes #391 My Widgets - clicking on collaborate too fast cause
collaborators to be empty
