### PR TITLE
Append widget created_at time when loading HTML

### DIFF
--- a/src/coffee/controllers/ctrl-create.coffee
+++ b/src/coffee/controllers/ctrl-create.coffee
@@ -168,7 +168,7 @@ app.controller 'createCtrl', ($scope, $sce, $timeout, widgetSrv) ->
 		dfd.promise()
 
 	embedHTML = (htmlPath, dfd) ->
-		$scope.htmlPath = htmlPath
+		$scope.htmlPath = htmlPath + "?" + widget_info.created_at
 		$scope.$apply()
 		embedDoneDfd = dfd
 

--- a/src/coffee/controllers/ctrl-player.coffee
+++ b/src/coffee/controllers/ctrl-player.coffee
@@ -166,7 +166,7 @@ app.controller 'playerCtrl', ($scope, $sce, $timeout, widgetSrv, userServ, PLAYE
 		embedDoneDfD = dfd
 
 		$scope.type = "html"
-		$scope.htmlPath = enginePath
+		$scope.htmlPath = enginePath + "?" + instance.widget.created_at
 		$('#'+PLAYER.EMBED_TARGET).width instance.widget.width if instance.widget.width > 0
 		$('#'+PLAYER.EMBED_TARGET).height instance.widget.height if instance.widget.height > 0
 


### PR DESCRIPTION
This will apply a cache breaker based on the last time a widget was
installed.

This solves #324 because all the data for a widget is wrapped up into the HTML file when its compiled for being installed. But when the widget is installed, the HTML can be cached and the users will not get the newest copy of a widget until they force a cache clear. By adding a cache breaker based on install time, the widget served will always be the latest copy.

Updates #324
