### PR TITLE
Issue/559 audio import capable

### DIFF
--- a/src/coffee/controllers/ctrl-media-import.coffee
+++ b/src/coffee/controllers/ctrl-media-import.coffee
@@ -105,7 +105,7 @@ app.controller 'mediaImportCtrl', ($scope, $sce, $timeout, $window, $document) -
 		$(".plupload_droptext", upl).text("Drag a file here to upload")
 
 		# click listener for each row
-		$($document).on 'click', '#question-table tbody tr', (e) ->
+		$($document).on 'click', '#question-table tbody tr[role=row]', (e) ->
 			#get index of row in datatable and call onMediaImportComplete to exit
 			$(".row_selected").toggleClass('row_selected')
 			index = $('#question-table').dataTable().fnGetPosition(this)


### PR DESCRIPTION
mp3 files are now upload-capable in the flash cards widget. As it is, videos are upload-capable in the mp4 format, as well. My next task is to determine if this is true for all our supported browsers.

See "issue/605-video-import-capable" for work in that direction.

See "issue/607-Media-Importer-File-Specific" for work in the direction filtering the media importer by media types.
