### PR TITLE
Add a limit to results returned from search

### DIFF
--- a/fuel/app/classes/model/user.php
+++ b/fuel/app/classes/model/user.php
@@ -95,6 +95,7 @@ class Model_User extends Orm\Model
 					->or_where('email', 'LIKE', "$name%")
 				->and_where_close()
 			->group_by(\Model_User::table().'.id')
+			->limit(50)
 			->as_object("Model_User")
 			->execute();
 


### PR DESCRIPTION
Search is returning too many results and sometimes crashes Materia or
Robohash. There aren't a lot of cases where you would want more than 50
results at a time. Narrow that down.

Updates #416
