### PR TITLE
Fix endless loop in LTI learner test.

### DIFF
--- a/fuel/app/modules/lti/classes/controller/test.php
+++ b/fuel/app/modules/lti/classes/controller/test.php
@@ -88,6 +88,8 @@ class Controller_Test extends \Controller_Rest
 	public function post_learner()
 	{
 		$lti_url          = static::get_and_unset_post('lti_url');
+		if (empty($lti_url)) return \Response::forge('LTI Assignment URL can not be blank!', 500);
+
 		$resource_link_id = static::get_and_unset_post('resource_link');
 		$custom_inst_id   = static::get_and_unset_post('custom_widget_instance_id');
 


### PR DESCRIPTION
Fixes #759.

Added check to LTI Learner test endpoint to prevent infinite loops and return an error message when trying to run the test without necessary information.
