### PR TITLE
Add method to allow score modules to query session logs.

### DIFF
--- a/fuel/packages/materia/classes/score/module.php
+++ b/fuel/packages/materia/classes/score/module.php
@@ -339,8 +339,11 @@ abstract class Score_Module
 		return $question->questions[0]['text'];
 	}
 
-	protected static function query_logs($where_conditions, $order_conditions=null, $group_conditions=null)
+	/**
+	* Proxy function to query session logs based on some parameters given by a widget score module
+	*/
+	protected final function query_logs($where_conditions, $order_conditions=null, $group_conditions=null)
 	{
-		return Session_Logger::query_logs($where_conditions, $order_conditions, $group_conditions);
+		return Session_Logger::query_logs($this->inst->id, $where_conditions, $order_conditions, $group_conditions);
 	}
 }


### PR DESCRIPTION
Fixes #764. `query_logs` method added to `Session_Logger` so logs can be queried safely from score modules.
