### PR TITLE
adds ability for tests to define authdriver for lti in tests

### DIFF
--- a/fuel/app/modules/lti/classes/ltiusermanager.php
+++ b/fuel/app/modules/lti/classes/ltiusermanager.php
@@ -48,7 +48,11 @@ class LtiUserManager
 				}
 			}
 
-			return (bool) \Auth::instance()->force_login($user->id);
+			// For some reason unkown to us - passing the authdriver here causes a strange error on production
+			// The user can start playing a widget, but the playid is registered to userid 0
+			// But for testing, we need to be able to specify the auth driver
+			if (\Fuel::$env !== \Fuel::TEST) $auth_driver = null;
+			return (bool) \Auth::instance($auth_driver)->force_login($user->id);
 		}
 
 		\Auth::logout();


### PR DESCRIPTION
Production problems were found by passing valid strings to `\Auth::instance()` so we removed it to avoid some crazy problems.  However, the tests rely on this ability.  So here's a quick hack to unset the auth driver if we're not in the TEST environment and return the force_login call back to it's original syntax.

references issue #766
