### PR TITLE
Omit context ID from used attempts calculation.

### DIFF
--- a/fuel/packages/materia/classes/api/v1.php
+++ b/fuel/packages/materia/classes/api/v1.php
@@ -491,7 +491,7 @@ class Api_V1
 		if ( ! $inst->playable_by_current_user()) return Msg::no_login();
 
 		$scores = Score_Manager::get_instance_score_history($inst_id);
-		$attempts_used = count(Score_Manager::get_instance_score_history($inst_id, $context_id, $semester));
+		$attempts_used = count(Score_Manager::get_instance_score_history($inst_id, null, $semester));
 		$extra = Score_Manager::get_instance_extra_attempts($inst_id, \Model_User::find_current_id(), $context_id, $semester);
 
 		$attempts_left = $inst->attempts - $attempts_used + $extra;


### PR DESCRIPTION
When visiting the score screen, only semester is factored into 'used attempts'.
