### PR TITLE
Updated Y offset of infocard selection to reduce chance of failure

### DIFF
--- a/spec/guest-access.spec.coffee
+++ b/spec/guest-access.spec.coffee
@@ -11,7 +11,7 @@ describe 'Guest Access Feature', ->
 	it 'should let an instructor create a guest access widget', (done) ->
 		setup.loginAt client, setup.author, "#{setup.url}/users/login"
 		client.url("#{setup.url}/widgets")
-			.moveToObject('.widget.enigma .infocard', 10, 10)
+			.moveToObject('.widget.enigma .infocard', 10, 100)
 			.click('.infocard:hover .header')
 			.pause(5000)
 			.click('#createLink')

--- a/spec/widget-catalog.spec.coffee
+++ b/spec/widget-catalog.spec.coffee
@@ -83,7 +83,7 @@ describe 'Widget Catalog Page', ->
 
 				for i in [1...result.value]
 					client
-						.moveToObject ".widget:nth-child(#{i}) .infocard", 10, 10
+						.moveToObject ".widget:nth-child(#{i}) .infocard", 10, 85
 						.getText ".widget:nth-child(#{i}) .widgetMin .header", (err, title) ->
 							currentTitle = title
 							expect(currentTitle).toBeTruthy()

--- a/spec/widget.spec.coffee
+++ b/spec/widget.spec.coffee
@@ -17,7 +17,7 @@ describe 'When I create a widget', ->
 		setup.loginAt client, setup.author, "#{setup.url}/users/login"
 		client.url("#{setup.url}/widgets")
 			.getTitle (err, title) -> expect(title).toBe('Widget Catalog | Materia')
-			.moveToObject('.widget.enigma .infocard', 10, 10)
+			.moveToObject('.widget.enigma .infocard', 10, 85)
 			.click('.infocard:hover .header')
 			.pause(5000)
 			.click('#createLink')
@@ -67,7 +67,7 @@ describe 'When I create a widget', ->
 	it 'should be able to make and play a published widget', (done) ->
 		client.url("#{setup.url}/widgets")
 			.getTitle (err, title) -> expect(title).toBe('Widget Catalog | Materia')
-			.moveToObject('.widget.enigma .infocard', 10, 10)
+			.moveToObject('.widget.enigma .infocard', 10, 85)
 			.click('.infocard:hover .header')
 			.pause(5000)
 			.click('#createLink')

--- a/spec/widgets/widgets.coffee
+++ b/spec/widgets/widgets.coffee
@@ -20,7 +20,7 @@ module.exports = (widget, callback) ->
 	client
 		.url("#{environment.url}/widgets")
 		.waitFor(".widget.#{widget}", 3000)
-		.moveToObject(".widget.#{widget} .infocard", 10, 10)
+		.moveToObject(".widget.#{widget} .infocard", 10, 85)
 		.waitFor('.infocard:hover .header h1', 4000)
 		.click('.infocard:hover .header')
 		.pause 5000


### PR DESCRIPTION
The problem:

Because of how the catalog works now, Selenium can't simply select the DOM element representing a given widget. It circumvents this by moving the virtual cursor over the widget, so the infocard appears, and then selecting the infocard, as a user would.

However, in many cases, the infocard from the _widget directly above_ the target widget loads instead, causing problems or making the infocard un-selectable. I've attempted to remedy this by moving the Y offset of the `moveToObject` command further down.

The issue usually manifests at the very beginning of the test, on line 14 of `guest-access.spec.coffee`.

Selenium being what it is, this isn't a guaranteed fix. I've run the tests over a dozen times and it fails a good 50% of the time, regardless of Y-value used. There may be some additional wonkiness at play here I haven't figured out, and there's very likely to be a better fix I'm not seeing.

This connects to #830
