### PR TITLE
Restores pre-widget login event trigger.

### DIFF
--- a/fuel/app/classes/controller/widgets.php
+++ b/fuel/app/classes/controller/widgets.php
@@ -371,7 +371,9 @@ class Controller_Widgets extends Controller
 
 		if ($is_open)
 		{
+			// fire an event prior to deciding which theme to render
 			$alt = \Event::Trigger('before_widget_login');
+			// if something came back as a result of the event being triggered, use that instead of the default
 			$theme = $alt ?: 'partials/widget/login';
 			$content = $this->theme->set_partial('content', $theme);
 			$content


### PR DESCRIPTION
Closes #873.

Restores some code in the Widgets controller that allows installed packages to capture an event that fires prior to attempting widget login and supply a theme to use instead of the default.
