### PR TITLE
Upgrade tasks to generate test users.

### DIFF
--- a/fuel/packages/materia/tasks/admin.php
+++ b/fuel/packages/materia/tasks/admin.php
@@ -320,7 +320,7 @@ class Admin extends \Basetask
 
 	}
 
-	public static function instant_user($name = false, $role = 'basic_author')
+	public static function instant_user($name = null, $role = 'basic_author')
 	{
 		if (\Fuel::$env != \Fuel::DEVELOPMENT) return;
 


### PR DESCRIPTION
Closes #697.

Instant user task modified to create a generic unofficial test user when not provided with a specific username. New task 'quick_test_users' will generate the specified number of generic unofficial test users, or 10 if not provided a number.
