### PR TITLE
Collaboration Timing Issue Fix

### DIFF
--- a/src/coffee/controllers/ctrl-widget-settings.coffee
+++ b/src/coffee/controllers/ctrl-widget-settings.coffee
@@ -200,8 +200,6 @@ app.controller 'WidgetSettingsController', ($scope, $filter, $window, selectedWi
 				$scope.$broadcast 'widgetAvailability.update', ''
 				selectedWidgetSrv.updateAvailability(attempts, $scope.times[0], $scope.times[1], $scope.guestAccess, $scope.embeddedOnly)
 
-		# selectedWidgetSrv.updateAvailability(attempts, $scope.times[0], $scope.times[1], $scope.guestAccess, $scope.embeddedOnly)
-
 	$scope.UNLIMITED_SLIDER_VALUE = 25
 	$scope.times = []
 	$scope.error = ''


### PR DESCRIPTION
Two separate calls were being made to the API - one to save changes to the settings of a widget instance, and one to get a list of all people with permission to that widget instance. Normally the first happens quickly enough that the second will still execute successfully, but it was determined that this won't necessarily be the case.

Making sure these two calls happen in sequence solves the problem.
