### PR TITLE
removes bowerrc so yarn doesnt destroy the directory

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,0 @@
-{
-	"directory": "public/assets/js/lib/bower"
-}


### PR DESCRIPTION
We don't use bower, so we don't need this file.  Also, it's causing a major problem with Yarn.