### PR TITLE
Removed the 'a' tag from the embedded iframe.

### DIFF
--- a/src/coffee/controllers/ctrl-selectedwidget.coffee
+++ b/src/coffee/controllers/ctrl-selectedwidget.coffee
@@ -53,7 +53,7 @@ app.controller 'SelectedWidgetController', ($scope, $q, widgetSrv,selectedWidget
 		height = if String($scope.selected.widget.widget.height) != '0' then $scope.selected.widget.widget.height else 600
 		draft = if $scope.selected.widget.is_draft then "#{$scope.selected.widget.widget.name} Widget" else $scope.selected.widget.name
 
-		"<iframe src='#{BASE_URL}embed/#{$scope.selected.widget.id}/#{$scope.selected.widget.clean_name}' width='#{width}' height='#{height}' style='margin:0;padding:0;border:0;'><a href='#{BASE_URL}play/#{$scope.selected.widget.id}/#{$scope.selected.widget.clean_name}'>#{draft}</a></iframe>"
+		"<iframe src='#{BASE_URL}embed/#{$scope.selected.widget.id}/#{$scope.selected.widget.clean_name}' width='#{width}' height='#{height}' style='margin:0;padding:0;border:0;'></iframe>"
 
 	$scope.enableOlderScores = ->
 		$scope.show.olderScores = true


### PR DESCRIPTION
The anchor tags have been removed. I had to manually add the embed iframe to the new canvas page. The existing "add a widget" method imports a new widget from Materia production, on which the new change does not exist.

The new change doesn't appear to break the pipeline at all:

![screen shot 2016-12-14 at 11 12 33 am](https://cloud.githubusercontent.com/assets/10148684/21189860/fb3ce3ec-c1ed-11e6-8c10-92db2c186b5c.png)

However, I wasn't able to reproduce the error the client was talking about. The embed iframe for a page (with anchor tags) was working fine for me. Maybe they were doing it in an unusual way to trigger said problems. At least, this change causes no unforeseen breakage in the system. Whether it fixes the complaining client's issue will require followup with them after Q/A proves this change causes no harm, then merged into production, and the client can try again.