### PR TITLE
Prevents <script> tags from firing from title

### DIFF
--- a/src/coffee/materia/materia.creatorcore.coffee
+++ b/src/coffee/materia/materia.creatorcore.coffee
@@ -13,6 +13,10 @@ Namespace('Materia').CreatorCore = do ->
 	_resizeInterval = null
 	_lastHeight = -1
 
+	PRESANITIZE_CHARACTERS =
+		'>': '',
+		'<': ''
+
 	_onPostMessage = (e) ->
 		msg = JSON.parse e.data
 		switch msg.type
@@ -69,11 +73,18 @@ Namespace('Materia').CreatorCore = do ->
 	getMediaUrl = (mediaId) ->
 		_baseurl+'media/'+mediaId
 
+	# replace a specified list of characters with their safe equivalents
+	_preSanitize = (text) ->
+		for k, v of PRESANITIZE_CHARACTERS
+			text = text.replace new RegExp(k, 'g'), v
+		return text
+
 	showMediaImporter = (types = ['jpg','jpeg','gif','png']) ->
 		_sendPostMessage 'showMediaImporter', types
 
 	save = (title, qset, version = '1') ->
-		_sendPostMessage 'save', [title, qset, version]
+		sanitizedTitle = _preSanitize title
+		_sendPostMessage 'save', [sanitizedTitle, qset, version]
 
 	cancelSave = (msg) ->
 		_sendPostMessage 'cancelSave', [msg]


### PR DESCRIPTION
This strips out the '<' and '>' character from the title before committing to Materia. This is to prevent the rare occasion that a user injects script tags, and though Materia doesn't seem to run those script tags from within the 'My Widgets' section, it will prevent future changes to Materia from opening this potential security gap.

Closes #922.