### PR TITLE
Reset dialogues/alerts/popups when selecting a widget on the My Widgets page.

### DIFF
--- a/src/coffee/controllers/ctrl-my-widgets.coffee
+++ b/src/coffee/controllers/ctrl-my-widgets.coffee
@@ -129,7 +129,16 @@ app.controller 'MyWidgetsController', ($scope, $q, $window, widgetSrv, userServ,
 	populateDisplay = ->
 		# reset scope variables to defaults
 		count = null
+
 		$scope.show.olderScores = false
+		$scope.show.availabilityModal = false
+		$scope.show.collaborationModal = false
+		$scope.show.copyModal = false
+		$scope.show.deleteDialog = false
+		$scope.show.editPublishedWarning = false
+		$scope.show.exportModal = false
+		$scope.show.olderScores = false
+
 		$scope.selected.accessLevel = 0
 		$scope.selected.editable = true
 		$scope.selected.shareable = false


### PR DESCRIPTION
Fixes #961.

Various warnings/popups e.g. the Delete, Collaborate, Access Options dialogues now reset when a new widget is selected.