### PR TITLE
Wrapped property reference in clear_fuel_input with try/catch

### DIFF
--- a/fuel/app/classes/basetest.php
+++ b/fuel/app/classes/basetest.php
@@ -24,9 +24,14 @@ class Basetest extends TestCase
 		$class = new ReflectionClass("\Fuel\Core\Input");
 		foreach (['detected_uri', 'detected_ext', 'input', 'put_patch_delete', 'php_input', 'json', 'xml'] as $value)
 		{
-			$property = $class->getProperty($value);
-			$property->setAccessible(true);
-			$property->setValue(null);
+			try
+			{
+				$property = $class->getProperty($value);
+				$property->setAccessible(true);
+				$property->setValue(null);
+
+			}
+			catch (ReflectionException $e) {}
 		}
 	}
 


### PR DESCRIPTION
Since I'm not entirely certain what `clear_fuel_input()` does, I'm not sure about the best way to handle this, and I'm also not certain where the `detected_uri` reference first broke. Regardless, wrapping that block in a try/catch allows the tests to proceed normally - but it may not be the desired solution. Would like a second opinion.