### PR TITLE
Adjust RocketDuck file render override to work with Apache again.

### DIFF
--- a/fuel/app/config/development/file.php
+++ b/fuel/app/config/development/file.php
@@ -1,0 +1,6 @@
+<?php
+
+return array(
+	'enable_mod_xsendfile' => true,
+	'enable_x_accel'       => true,
+);

--- a/fuel/packages/rocketduck/classes/fuel/core/file.php
+++ b/fuel/packages/rocketduck/classes/fuel/core/file.php
@@ -11,7 +11,7 @@ class File extends Fuel\Core\File
 		if (\Config::get('file.enable_mod_xsendfile', false) && function_exists('apache_get_modules') && in_array('mod_xsendfile', apache_get_modules()))
 		{
 			$sendfile = true;
-			$sendfile_header = 'X-SendFile: '.$info['realpath'];
+			$sendfile_header = 'X-SendFile: '.$path;
 		}
 
 		// send file using nginx's x_accel?


### PR DESCRIPTION
Fixes #1021.

Added file config to development environment config, for overrides as necessary. Changed Apache handler in RocketDuck's file rendering override to use the given path instead of whatever it was trying to do before.