### PR TITLE
Supply explicit defaults when looking up IP address.

### DIFF
--- a/fuel/app/classes/model/user.php
+++ b/fuel/app/classes/model/user.php
@@ -138,11 +138,11 @@ class Model_User extends Orm\Model
 
 	static protected function get_rate_limiter()
 	{
-		$limit = Cache::easy_get('rate-limit.'.str_replace('.', '-', Input::real_ip()));
+		$limit = Cache::easy_get('rate-limit.'.str_replace('.', '-', Input::real_ip('0.0.0.0', true)));
 		if (is_null($limit))
 		{
 			$limit = ['start_time' => time(), 'count' => 0];
-			Cache::set('rate-limit.'.str_replace('.', '-', Input::real_ip()), $limit, self::RATE_LIMITER_DOWN_TIME);
+			Cache::set('rate-limit.'.str_replace('.', '-', Input::real_ip('0.0.0.0', true)), $limit, self::RATE_LIMITER_DOWN_TIME);
 		}
 		return $limit;
 	}
@@ -172,13 +172,13 @@ class Model_User extends Orm\Model
 			{
 				$limit['count'] += 1 ;
 			}
-			Cache::set('rate-limit.'.str_replace('.', '-', Input::real_ip()), $limit, self::RATE_LIMITER_DOWN_TIME);
+			Cache::set('rate-limit.'.str_replace('.', '-', Input::real_ip('0.0.0.0', true)), $limit, self::RATE_LIMITER_DOWN_TIME);
 		}
 	}
 
 	static protected function reset_rate_limiter()
 	{
-		if ( ! Fuel::$is_cli) Cache::delete('rate-limit.'.str_replace('.', '-', Input::real_ip()));
+		if ( ! Fuel::$is_cli) Cache::delete('rate-limit.'.str_replace('.', '-', Input::real_ip('0.0.0.0', true)));
 	}
 
 	static public function login($username, $password)

--- a/fuel/packages/materia/classes/session/file.php
+++ b/fuel/packages/materia/classes/session/file.php
@@ -43,7 +43,7 @@ class Session_File extends \Session_Driver
 		// create a new session
 		$this->keys['session_id']  = $this->_new_session_id();
 		$this->keys['previous_id'] = $this->keys['session_id'];	// prevents errors if previous_id has a unique index
-		$this->keys['ip_hash']     = md5(\Input::ip().\Input::real_ip());
+		$this->keys['ip_hash']     = md5(\Input::ip().\Input::real_ip('0.0.0.0', true));
 		$this->keys['user_agent']  = \Input::user_agent();
 		$this->keys['created']     = $this->time->get_timestamp();
 		$this->keys['updated']     = $this->keys['created'];


### PR DESCRIPTION
Closes #1031.

Updated all places using Fuel's 'real_ip' method to be explicit with defaults and ignoring reserved results.