### PR TITLE
flatten and combine log output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ desktop.ini
 
 # dynamically generated files
 /fuel/app/logs/**/*
+/fuel/app/logs/*
 /fuel/app/cache/**/*
 /fuel/app/config/crypt.php
 /fuel/app/config/development/crypt.php

--- a/fuel/packages/rocketduck/classes/fuel/core/log.php
+++ b/fuel/packages/rocketduck/classes/fuel/core/log.php
@@ -11,66 +11,34 @@ class Log extends Fuel\Core\Log
 		// load the file config
 		\Config::load('file', true);
 
+		// determine the name and location of the logfile
+		$path     = \Config::get('log_path', APPPATH.'logs'.DS);
+		$filename = \Config::get('log_file', 'materia');
+		if (empty($filename))
+		{
+			$filename = 'materia';
+		}
+		$filepath = $path.$filename;
+
 		// make sure the log directories exist
-		try
+		if ( ! is_dir($path))
 		{
-			// determine the name and location of the logfile
-			$path     = \Config::get('log_path', APPPATH.'logs'.DS);
-			$filename = \Config::get('log_file', null);
-
-			if(empty($filename))
-			{
-				$rootpath = $path.date('Y').DS;
-				$filepath = $path.date('Y/m').DS;
-				$filename = $filepath.date('d').'.php';
-			}
-			else
-			{
-				$rootpath = $path;
-				$filepath = $path;
-				$filename = $path.$filename;
-			}
-
-			// get the required folder permissions
 			$permission = \Config::get('file.chmod.folders', 0777);
-
-			if ( ! is_dir($rootpath))
-			{
-				mkdir($rootpath, 0777, true);
-				chmod($rootpath, $permission);
-			}
-			if ( ! is_dir($filepath))
-			{
-				mkdir($filepath, 0777, true);
-				chmod($filepath, $permission);
-			}
-
-			$handle = fopen($filename, 'a');
+			mkdir($path, 0777, true);
+			chmod($path, $permission);
 		}
-		catch (\Exception $e)
-		{
-			\Config::set('log_threshold', \Fuel::L_NONE);
-			throw new \FuelException('Unable to create or write to the log file. Please check the permissions on '.\Config::get('log_path').'. ('.$e->getMessage().')');
-		}
-
-		if ( ! filesize($filename))
-		{
-			fwrite($handle, "<?php defined('COREPATH') or exit('No direct script access allowed'); ?>".PHP_EOL.PHP_EOL);
-			chmod($filename, \Config::get('file.chmod.files', 0666));
-		}
-		fclose($handle);
 
 		if ($handler_factory = \Config::get('log_handler_factory'))
 		{
-			$stream = $handler_factory(get_defined_vars(), \Monolog\Logger::DEBUG);
+			$handler = $handler_factory(get_defined_vars(), \Monolog\Logger::DEBUG);
 		}
 		else
 		{
-			$stream = new \Monolog\Handler\StreamHandler($filename, \Monolog\Logger::DEBUG);
+			$handler = new \Monolog\Handler\RotatingFileHandler($filepath, 0, \Monolog\Logger::DEBUG);
 		}
 
 		$formatter = new \Monolog\Formatter\LineFormatter("%level_name% - %datetime% --> %message%".PHP_EOL, "Y-m-d H:i:s", true);
-		$stream->setFormatter($formatter);
-		static::$monolog->pushHandler($stream);
+		$handler->setFormatter($formatter);
+		static::$monolog->pushHandler($handler);
 	}
 }

--- a/fuel/packages/rocketduck/classes/log.php
+++ b/fuel/packages/rocketduck/classes/log.php
@@ -16,12 +16,32 @@ class Log
 	{
 		! class_exists('Log') and \Package::load('log');
 
+		$log_combine = \Config::get('log_combine', false);
+
+		// ====== DEAL WITH THE MESSAGE ARRAY =========
+		if ($start_time) $msg[] = round((microtime(true) - $start_time), 5); // if start time sent, calculate the elapsed and append
+
+		$output = "$type: \"".implode('","', (array) $msg).'"';
+
+		if ($log_combine)
+		{
+			\Fuel\Core\Log::debug($output);
+		}
+		else
+		{
+			$logger = static::prepare_logger($type);
+			$logger->error($output);
+		}
+	}
+
+	protected static function prepare_logger($type)
+	{
 		// ======= DEAL WITH MONOLOG ===============
 		// setup monolog and the stream handler that writes to each specific file
 		if ( ! isset(static::$monolog))
 		{
 			static::$monolog = new \Monolog\Logger('profiles');
-			static::$formatter = new \Monolog\Formatter\LineFormatter('%message%'.PHP_EOL, 'Y-m-d H:i:s', true);
+			static::$formatter = new \Monolog\Formatter\LineFormatter('%level_name% - %datetime% --> %message%'.PHP_EOL, 'Y-m-d H:i:s', true);
 		}
 
 		// if the profile type has changed (prev null or different)
@@ -39,7 +59,7 @@ class Log
 			}
 			else
 			{
-				$handler = new \Monolog\Handler\StreamHandler($filename, \Monolog\Logger::DEBUG);
+				$handler = new \Monolog\Handler\RotatingFileHandler($filename, 0, \Monolog\Logger::DEBUG);
 			}
 
 			$handler->setFormatter(static::$formatter);
@@ -47,22 +67,16 @@ class Log
 			static::$prev_type = $type;
 		}
 
-
-		// ====== DEAL WITH THE MESSAGE ARRAY =========
-		$msg[] = time(); // add timestamp to values
-		if ($start_time) $msg[] = round((microtime(true) - $start_time), 5); // if start time sent, calculate the elapsed and append
-
-		static::$monolog->error("$type: \"".implode('","', (array) $msg).'"');
+		return static::$monolog;
 	}
 
 	protected static function prepare_file($type)
 	{
-				// ======= DEAL WITH THE FILE AND DIRECTORY =====
 		// load the file config
 		\Config::load('file', true);
 
 		// determine the name and location of the logfile
-		$filepath = \Config::get('log_path').date('Y/m').'/';
+		$filepath = \Config::get('log_path').DS;
 
 		if ( ! is_dir($filepath))
 		{
@@ -71,12 +85,6 @@ class Log
 			umask($old);
 		}
 
-		$filename = $filepath.date('d')."-$type.php";
-
-		if ( ! file_exists($filename))
-		{
-			file_put_contents($filename, '<'."?php defined('COREPATH') or exit('No direct script access allowed'); ?".'>'.PHP_EOL.PHP_EOL);
-		}
-		return $filename;
+		return $filepath.DS.$type;
 	}
 }


### PR DESCRIPTION
For easier logging and log tracking in production - I'd like to offer the ability to combine all logs into one file.

At the same time, I'd like to bypass the fuelphp logic for creating new files/directories for the logs.

Instead of fuel/app/logs/YYYY/MM/DD.php, we'll just use Monolog's RotatingFileHandler and they'll all end up in fuel/app/logs/materia-YYYY-MM-DD

By default the other log files will be created the same way, but I'd like to add a fuel config option named log_combine. When set to true the calls to \RocketDuck\Log::profile will just short circuit into Fuel logs, ending up combined into materia-YYYY-MM-DD


fixes #1084 