### PR TITLE
LTI scores are now accessible from outside the LTI.

### DIFF
--- a/fuel/packages/materia/classes/api/v1.php
+++ b/fuel/packages/materia/classes/api/v1.php
@@ -499,7 +499,7 @@ class Api_V1
 	static public function widget_instance_scores_get($inst_id, $token=false)
 	{
 		$result = $token ? \Event::trigger('before_score_display', $token) : null;
-		$context_id = empty($result) ? '' : $result;
+		$context_id = empty($result) ? null : $result;
 		if ( ! $token && \Session::get('context_id', false)) $context_id = \Session::get('context_id');
 
 		$semester = Semester::get_current_semester();


### PR DESCRIPTION
Fixes #1086.

When looking up scores, the API attempts to get a context ID from the provided token to pass onto the score manager, which will then only look for scores for the given context id. If it doesn't receive a context ID, it just brings up all scores for the given instance/player.

Context ID was being set to `''`, an empty string, which was triggering the score manager's checks and making scores from embedded plays inaccessible from outside of the LTI.

Setting context ID to `null` instead solves the problem.