### PR TITLE
Default score screen should use a table to display scores.

### DIFF
--- a/fuel/app/themes/default/partials/score/full.php
+++ b/fuel/app/themes/default/partials/score/full.php
@@ -68,25 +68,28 @@
 
 	<section class="details" ng-repeat="detail in details" ng-show="showResultsTable && !restricted && !expired">
 		<h1>{{ detail.title }}</h1>
-		<ul>
-			<li class="details_header">
-				<h3 ng-repeat="header in detail.header">{{ header }}</h3>
-			</li>
-			<li class="{{ row.style }}" ng-repeat-start="row in detail.table">
-				<div class="index" ng-if="row.graphic != 'none'">
+
+		<table>
+			<tr class="details_header">
+				<th ng-repeat="header in detail.header">{{ header }}</th>
+			</tr>
+			<tr class="{{ row.style }}" ng-class="{ has_feedback: row.feedback != null }" ng-repeat-start="row in detail.table">
+				<td class="index" ng-if="row.graphic != 'none'">
 					<canvas class="question-number" id="question-{{ $parent.$parent.$index+1 }}-{{ $index+1 }}" >
 						<p>{{ $index+1 }}</p>
 					</canvas>
 					<span ng-if="row.display_score">
 						{{ row.score }}{{ row.symbol }}
 					</span>
-				</div>
-				<div class="{{ row.data_style[$index] }}" ng-repeat="data in row.data track by $index">{{ data }}</div>
-			</li>
-			<li ng-if="row.feedback != null" class="feedback single_column" ng-repeat-end>
-				<p>{{ row.feedback }}</p>
-			</li>
-		</ul>
+				</td>
+				<td class="{{ row.data_style[$index] }}" ng-repeat="data in row.data track by $index">{{ data }}</td>
+			</tr>
+			<tr ng-if="row.feedback != null" class="feedback single_column" ng-repeat-end>
+				<td colspan="{{ row.data.length + 1 }}">
+					<p>{{ row.feedback }}</p>
+				</td>
+			</tr>
+		</table>
 	</section>
 
 	<div class="expired container general" ng-show="expired">


### PR DESCRIPTION
Closes #1178.

Requires https://github.com/ucfopen/Materia-Server-Client-Assets/pull/32.

Changed default score screen to use a table instead of an unordered list pretending to be a table.