### PR TITLE
update and add default widgets from Github

### DIFF
--- a/fuel/app/config/config.php
+++ b/fuel/app/config/config.php
@@ -316,4 +316,58 @@ return array(
 			'login',
 		),
 	),
+
+	// which widgets are installed with the widget:install_from_config task
+	'widgets' => [
+		[
+			'id' => 1,
+			'package'  => 'https://github.com/ucfopen/crossword-materia-widget/releases/download/v1.2.3/crossword.wigt',
+			'checksum' => 'https://github.com/ucfopen/crossword-materia-widget/releases/download/v1.2.3/crossword-build-info.yml',
+		],
+		[
+			'id' => 2,
+			'package'  => 'https://github.com/ucfopen/hangman-materia-widget/releases/download/v1.1.2/hangman.wigt',
+			'checksum' => 'https://github.com/ucfopen/hangman-materia-widget/releases/download/v1.1.2/hangman-build-info.yml',
+		],
+		[
+			'id' => 3,
+			'package'  => 'https://github.com/ucfopen/matching-materia-widget/releases/download/v1.1.4/matching.wigt',
+			'checksum' => 'https://github.com/ucfopen/matching-materia-widget/releases/download/v1.1.4/matching-build-info.yml',
+		],
+		[
+			'id' => 4,
+			'package'  => 'https://github.com/ucfopen/enigma-materia-widget/releases/download/v2.1.1/enigma.wigt',
+			'checksum' => 'https://github.com/ucfopen/enigma-materia-widget/releases/download/v2.1.1/enigma-build-info.yml',
+		],
+		[
+			'id' => 5,
+			'package'  => 'https://github.com/ucfopen/labeling-materia-widget/releases/download/v1.0.3/labeling.wigt',
+			'checksum' => 'https://github.com/ucfopen/labeling-materia-widget/releases/download/v1.0.3/labeling-build-info.yml',
+		],
+		[
+			'id' => 6,
+			'package' => 'https://github.com/ucfopen/flash-cards-materia-widget/releases/download/v1.1.2/flash-cards.wigt',
+			'checksum' => 'https://github.com/ucfopen/flash-cards-materia-widget/releases/download/v1.1.2/flash-cards-build-info.yml'
+		],
+		[
+			'id' => 7,
+			'package' => 'https://github.com/ucfopen/this-or-that-materia-widget/releases/download/v1.0.6/this-or-that.wigt',
+			'checksum' => 'https://github.com/ucfopen/this-or-that-materia-widget/releases/download/v1.0.6/this-or-that-build-info.yml'
+		],
+		[
+			'id' => 8,
+			'package' => 'https://github.com/ucfopen/word-search-materia-widget/releases/download/v1.1.4/word-search.wigt',
+			'checksum' => 'https://github.com/ucfopen/word-search-materia-widget/releases/download/v1.1.4/word-search-build-info.yml'
+		],
+		[
+			'id' => 9,
+			'package' => 'https://github.com/ucfopen/adventure-materia-widget/releases/download/v2.0.6/adventure.wigt',
+			'checksum' => 'https://github.com/ucfopen/adventure-materia-widget/releases/download/v2.0.6/adventure-build-info.yml'
+		],
+		[
+			'id' => 10,
+			'package' => 'https://github.com/ucfopen/equation-sandbox-materia-widget/releases/download/v2.0.2/equation-sandbox.wigt',
+			'checksum' => 'https://github.com/ucfopen/equation-sandbox-materia-widget/releases/download/v2.0.2/equation-sandbox-build-info.yml'
+		]
+	],
 );

--- a/fuel/app/config/development/config.php
+++ b/fuel/app/config/development/config.php
@@ -21,31 +21,4 @@ return [
 	// see https://github.com/docker-library/php/issues/207 and https://github.com/php/php-src/pull/1076
 	// 'log_handler_factory'   => function($locals, $level){ return new \Monolog\Handler\ErrorLogHandler(); },
 
-	'widgets' => [
-		[
-			'id' => 1,
-			'package'  => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/crossword_1a9a888e5d540e4a8eeea6575abf6ea1170bba50.wigt',
-			'checksum' => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/crossword_1a9a888e5d540e4a8eeea6575abf6ea1170bba50.wigt.yml',
-		],
-		[
-			'id' => 2,
-			'package'  => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/hangman_8150b16085050dde81a7c727b8b946a679082895.wigt',
-			'checksum' => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/hangman_8150b16085050dde81a7c727b8b946a679082895.wigt.yml',
-		],
-		[
-			'id' => 3,
-			'package'  => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/matching_e7b6fa775eb54427045fff136a33c179affc681d.wigt',
-			'checksum' => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/matching_e7b6fa775eb54427045fff136a33c179affc681d.wigt.yml',
-		],
-		[
-			'id' => 4,
-			'package'  => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/enigma_8d63e47cdef1297da78c4e5f36e3507edc2c0e4e.wigt',
-			'checksum' => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/enigma_8d63e47cdef1297da78c4e5f36e3507edc2c0e4e.wigt.yml',
-		],
-		[
-			'id' => 5,
-			'package'  => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/labeling_3bb91ca43aef61e252c58015631fb3cbc713badf.wigt',
-			'checksum' => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/labeling_3bb91ca43aef61e252c58015631fb3cbc713badf.wigt.yml',
-		],
-	],
 ];

--- a/fuel/app/config/heroku/config.php
+++ b/fuel/app/config/heroku/config.php
@@ -6,31 +6,4 @@ return [
 	# send logs via STDOUT for heroku
 	'log_handler_factory'   => function($locals, $level){ return new \Monolog\Handler\ErrorLogHandler(); },
 
-	'widgets' => [
-		[
-			'id' => 1,
-			'package'  => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/crossword_1a9a888e5d540e4a8eeea6575abf6ea1170bba50.wigt',
-			'checksum' => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/crossword_1a9a888e5d540e4a8eeea6575abf6ea1170bba50.wigt.yml',
-		],
-		[
-			'id' => 2,
-			'package'  => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/hangman_8150b16085050dde81a7c727b8b946a679082895.wigt',
-			'checksum' => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/hangman_8150b16085050dde81a7c727b8b946a679082895.wigt.yml',
-		],
-		[
-			'id' => 3,
-			'package'  => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/matching_e7b6fa775eb54427045fff136a33c179affc681d.wigt',
-			'checksum' => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/matching_e7b6fa775eb54427045fff136a33c179affc681d.wigt.yml',
-		],
-		[
-			'id' => 4,
-			'package'  => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/enigma_8d63e47cdef1297da78c4e5f36e3507edc2c0e4e.wigt',
-			'checksum' => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/enigma_8d63e47cdef1297da78c4e5f36e3507edc2c0e4e.wigt.yml',
-		],
-		[
-			'id' => 5,
-			'package'  => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/adventure_66631aca57d255eb61854b02b14c63604d8e8a66.wigt',
-			'checksum' => 'https://ucfcdl-deploy-builds-public.s3.amazonaws.com/materia-widgets/adventure_66631aca57d255eb61854b02b14c63604d8e8a66.wigt.yml',
-		],
-	],
 ];


### PR DESCRIPTION
* Unifies the default widgets installed on Heroku and in Development.
* Expands the default widget set to 10
* Updates all widgets to the newest versions deployed to Github