### PR TITLE
Lock a widget instance in the creator rather than at the My Widgets screen.

### DIFF
--- a/fuel/app/classes/basetest.php
+++ b/fuel/app/classes/basetest.php
@@ -87,7 +87,7 @@ class Basetest extends TestCase
 		return \Materia\Widget_Manager::search($search)[0]->id;
 	}
 
-	protected function make_disposable_widget($name = 'TestWidget', $restricted = false)
+	protected function make_disposable_widget(string $name = 'TestWidget', bool $restrict_publish = false)
 	{
 		$user = $this->make_random_author();
 
@@ -103,7 +103,7 @@ class Basetest extends TestCase
 				'is_playable' => true,
 				'is_editable' => true,
 				'in_catalog' => true,
-				'restrict_publish' => $restricted,
+				'restrict_publish' => $restrict_publish,
 				'api_version' => 2,
 			],
 			'score' => [

--- a/fuel/app/classes/basetest.php
+++ b/fuel/app/classes/basetest.php
@@ -87,7 +87,7 @@ class Basetest extends TestCase
 		return \Materia\Widget_Manager::search($search)[0]->id;
 	}
 
-	protected function make_disposable_widget($name = 'TestWidget')
+	protected function make_disposable_widget($name = 'TestWidget', $restricted = false)
 	{
 		$user = $this->make_random_author();
 
@@ -103,6 +103,7 @@ class Basetest extends TestCase
 				'is_playable' => true,
 				'is_editable' => true,
 				'in_catalog' => true,
+				'restrict_publish' => $restricted,
 				'api_version' => 2,
 			],
 			'score' => [
@@ -134,6 +135,7 @@ class Basetest extends TestCase
 			'widget'          => $widget,
 			'is_student_made' => true,
 			'guest_access'    => true,
+			'published_by'    => $user->id,
 			'attempts'        => -1
 		]);
 		$demo_inst->db_store();

--- a/fuel/app/classes/basetest.php
+++ b/fuel/app/classes/basetest.php
@@ -87,7 +87,7 @@ class Basetest extends TestCase
 		return \Materia\Widget_Manager::search($search)[0]->id;
 	}
 
-	protected function make_disposable_widget(string $name = 'TestWidget', bool $restrict_publish = false)
+	protected function make_disposable_widget(string $name = 'TestWidget', bool $restrict_publish = false): \Materia\Widget
 	{
 		$user = $this->make_random_author();
 

--- a/fuel/app/classes/materia/api/v1.php
+++ b/fuel/app/classes/materia/api/v1.php
@@ -139,7 +139,7 @@ class Api_V1
 			'guest_access'    => $is_student,
 			'attempts'        => -1
 		]);
-		if ( ! $is_draft && ! $widget->publishable_by(\Model_User::find_current_id()) ) return new Msg(Msg::ERROR, 'Widget can not be published by student!');
+		if ( ! $is_draft && ! $widget->publishable_by(\Model_User::find_current_id()) ) return new Msg(Msg::ERROR, 'Widget type can not be published by students.');
 
 		if ( ! empty($qset->data)) $inst->qset->data = $qset->data;
 		if ( ! empty($qset->version)) $inst->qset->version = $qset->version;

--- a/fuel/app/classes/materia/api/v1.php
+++ b/fuel/app/classes/materia/api/v1.php
@@ -179,7 +179,7 @@ class Api_V1
 		$inst = Widget_Instance_Manager::get($inst_id, true);
 		if ( ! $inst) return new Msg(Msg::ERROR, 'Widget instance could not be found.');
 		if ( $is_draft && ! $inst->widget->is_editable) return new Msg(Msg::ERROR, 'Non-editable widgets can not be saved as drafts!');
-		if ( ! $is_draft && ! $inst->widget->publishable_by(\Model_User::find_current_id())) return new Msg(Msg::ERROR, 'Widgets can not be published by student!');
+		if ( ! $is_draft && ! $inst->widget->publishable_by(\Model_User::find_current_id())) return new Msg(Msg::ERROR, 'Widget type can not be published by students.');
 
 		// student made widgets are locked forever
 		if ($inst->is_student_made)

--- a/fuel/app/classes/materia/api/v1.php
+++ b/fuel/app/classes/materia/api/v1.php
@@ -68,6 +68,18 @@ class Api_V1
 		return $inst->db_remove();
 	}
 
+	/**
+	 * @return bool, true if the current user can publish the given widget instance, false otherwise.
+	 */
+	static public function publish_verify($inst_id)
+	{
+		if ( ! Util_Validator::is_valid_hash($inst_id)) return Msg::invalid_input($inst_id);
+		if (\Service_User::verify_session() !== true) return Msg::no_login();
+		if ( ! static::has_perms_to_inst($inst_id, [Perm::FULL])) return Msg::no_perm();
+		if ( ! ($inst = Widget_Instance_Manager::get($inst_id))) return false;
+		return $inst->publishable_by(\Model_User::find_current_id());
+	}
+
 	static private function has_perms_to_inst($inst_id, $perms)
 	{
 		return Perm_Manager::user_has_any_perm_to(\Model_User::find_current_id(), $inst_id, Perm::INSTANCE, $perms);
@@ -125,6 +137,7 @@ class Api_V1
 			'guest_access'    => $is_student,
 			'attempts'        => -1
 		]);
+		if ( ! $is_draft && ! $inst->publishable_by(\Model_User::find_current_id()) ) return new Msg(Msg::ERROR, 'Widget can not be published by student!');
 
 		if ( ! empty($qset->data)) $inst->qset->data = $qset->data;
 		if ( ! empty($qset->version)) $inst->qset->version = $qset->version;
@@ -164,6 +177,7 @@ class Api_V1
 		$inst = Widget_Instance_Manager::get($inst_id, true);
 		if ( ! $inst) return new Msg(Msg::ERROR, 'Widget instance could not be found.');
 		if ( $is_draft && ! $inst->widget->is_editable) return new Msg(Msg::ERROR, 'Non-editable widgets can not be saved as drafts!');
+		if ( ! $is_draft && ! $inst->publishable_by(\Model_User::find_current_id())) return new Msg(Msg::ERROR, 'Widgets can not be published by student!');
 
 		// student made widgets are locked forever
 		if ($inst->is_student_made)

--- a/fuel/app/classes/materia/session/activity.php
+++ b/fuel/app/classes/materia/session/activity.php
@@ -15,6 +15,7 @@ class Session_Activity
 		// Activity Types
 		const TYPE_CREATE_WIDGET            = 'createdWidget';
 		const TYPE_DELETE_WIDGET            = 'deletedWidget';
+		const TYPE_PUBLISH_WIDGET           = 'publishedWidget';
 		const TYPE_EDIT_WIDGET              = 'editedWidget';
 		const TYPE_EDIT_WIDGET_SETTINGS     = 'editedWidgetSettings';
 		const TYPE_LOGGED_IN                = 'loggedIn';

--- a/fuel/app/classes/materia/widget.php
+++ b/fuel/app/classes/materia/widget.php
@@ -34,6 +34,7 @@ class Widget
 	public $name                = '';
 	public $player              = '';
 	public $question_types      = '';
+	public $restrict_publish    = false;
 	public $score_module        = 'base';
 	public $score_screen        = '';
 	public $width               = 0;
@@ -114,6 +115,7 @@ class Widget
 			'is_scalable'         => $w['is_scalable'],
 			'score_module'        => $w['score_module'],
 			'score_screen'        => $w['score_screen'],
+			'restrict_publish'    => $w['restrict_publish'],
 			'is_storage_enabled'  => $w['is_storage_enabled'],
 			'package_hash'        => $w['package_hash'],
 			'width'               => $w['width'],

--- a/fuel/app/classes/materia/widget.php
+++ b/fuel/app/classes/materia/widget.php
@@ -273,6 +273,17 @@ class Widget
 		return $this->exporter_methods;
 	}
 
+	/**
+	 * Checks if user can publish widget.
+	 *
+	 * @return bool Whether or not the current user can publish the widget
+	 */
+	public function publishable_by($user_id)
+	{
+		if ( ! $this->restrict_publish) return true;
+		return ! Perm_Manager::is_student($user_id);
+	}
+
 	// filter out items in an array that aren't callable
 	public static function reduce_array_to_functions(array $array): array
 	{

--- a/fuel/app/classes/materia/widget.php
+++ b/fuel/app/classes/materia/widget.php
@@ -1,12 +1,4 @@
 <?php
-/**
- * The go between for the user and the Materia Package.
- *
- * The widget managers for the Materia package.
- *
- * @package	    Main
- * @author      Kevin Baugh
- */
 
 namespace Materia;
 
@@ -278,7 +270,7 @@ class Widget
 	 *
 	 * @return bool Whether or not the current user can publish the widget
 	 */
-	public function publishable_by($user_id)
+	public function publishable_by(int $user_id): bool
 	{
 		if ( ! $this->restrict_publish) return true;
 		return ! Perm_Manager::is_student($user_id);

--- a/fuel/app/classes/materia/widget/installer.php
+++ b/fuel/app/classes/materia/widget/installer.php
@@ -540,6 +540,7 @@ class Widget_Installer
 			'flash_version'       => $manifest_data['files']['flash_version'],
 			'height'              => $manifest_data['general']['height'],
 			'width'               => $manifest_data['general']['width'],
+			'author_only'         => Util_Validator::cast_to_bool_enum(isset($manifest_data['general']['author_only']) ? $manifest_data['general']['author_only'] : false),
 			'is_qset_encrypted'   => Util_Validator::cast_to_bool_enum($manifest_data['general']['is_qset_encrypted']),
 			'is_answer_encrypted' => Util_Validator::cast_to_bool_enum($manifest_data['general']['is_answer_encrypted']),
 			'is_storage_enabled'  => Util_Validator::cast_to_bool_enum($manifest_data['general']['is_storage_enabled']),

--- a/fuel/app/classes/materia/widget/installer.php
+++ b/fuel/app/classes/materia/widget/installer.php
@@ -540,7 +540,7 @@ class Widget_Installer
 			'flash_version'       => $manifest_data['files']['flash_version'],
 			'height'              => $manifest_data['general']['height'],
 			'width'               => $manifest_data['general']['width'],
-			'restrict_publish'    => Util_Validator::cast_to_bool_enum(isset($manifest_data['general']['restrict_publish']) ? $manifest_data['general']['restrict_publish'] : false),
+			'restrict_publish'    => isset($manifest_data['general']['restrict_publish']) ? Util_Validator::cast_to_bool_enum($manifest_data['general']['restrict_publish']) : '0',
 			'is_qset_encrypted'   => Util_Validator::cast_to_bool_enum($manifest_data['general']['is_qset_encrypted']),
 			'is_answer_encrypted' => Util_Validator::cast_to_bool_enum($manifest_data['general']['is_answer_encrypted']),
 			'is_storage_enabled'  => Util_Validator::cast_to_bool_enum($manifest_data['general']['is_storage_enabled']),

--- a/fuel/app/classes/materia/widget/installer.php
+++ b/fuel/app/classes/materia/widget/installer.php
@@ -540,7 +540,7 @@ class Widget_Installer
 			'flash_version'       => $manifest_data['files']['flash_version'],
 			'height'              => $manifest_data['general']['height'],
 			'width'               => $manifest_data['general']['width'],
-			'author_only'         => Util_Validator::cast_to_bool_enum(isset($manifest_data['general']['author_only']) ? $manifest_data['general']['author_only'] : false),
+			'restrict_publish'    => Util_Validator::cast_to_bool_enum(isset($manifest_data['general']['restrict_publish']) ? $manifest_data['general']['restrict_publish'] : false),
 			'is_qset_encrypted'   => Util_Validator::cast_to_bool_enum($manifest_data['general']['is_qset_encrypted']),
 			'is_answer_encrypted' => Util_Validator::cast_to_bool_enum($manifest_data['general']['is_answer_encrypted']),
 			'is_storage_enabled'  => Util_Validator::cast_to_bool_enum($manifest_data['general']['is_storage_enabled']),

--- a/fuel/app/classes/materia/widget/instance.php
+++ b/fuel/app/classes/materia/widget/instance.php
@@ -251,7 +251,7 @@ class Widget_Instance
 	{
 		// check for requirements
 		if ( ! $this->user_id > 0) return false;
-		if ( ! $this->publishable_by(\Model_User::find_current_id())) return false;
+		if ( ! $this->is_draft && ! $this->publishable_by(\Model_User::find_current_id())) return false;
 
 		$is_new = ! Util_Validator::is_valid_hash($this->id);
 

--- a/fuel/app/classes/materia/widget/instance.php
+++ b/fuel/app/classes/materia/widget/instance.php
@@ -24,6 +24,7 @@ class Widget_Instance
 	public $open_at         = -1;
 	public $play_url        = '';
 	public $preview_url     = '';
+	public $published_by    = null;
 	public $user_id         = 0;
 	public $widget          = null;
 	public $width           = 0;
@@ -250,6 +251,7 @@ class Widget_Instance
 	{
 		// check for requirements
 		if ( ! $this->user_id > 0) return false;
+		if ( ! $this->publishable_by(\Model_User::find_current_id())) return false;
 
 		$is_new = ! Util_Validator::is_valid_hash($this->id);
 
@@ -283,6 +285,7 @@ class Widget_Instance
 							'guest_access'    => Util_Validator::cast_to_bool_enum($this->guest_access),
 							'is_student_made' => Util_Validator::cast_to_bool_enum($this->is_student_made),
 							'embedded_only'   => Util_Validator::cast_to_bool_enum($this->embedded_only),
+							'published_by'    => $this->is_draft ? null : \Model_User::find_current_id()
 						])
 						->execute();
 
@@ -301,6 +304,9 @@ class Widget_Instance
 		}
 		else // ===================== UPDATE EXISTING INSTANCE =======================
 		{
+			$new_publisher = $this->published_by;
+			if ( ! $new_publisher && ! $this->is_draft) $new_publisher = \Model_User::find_current_id();
+
 			// store the question set if it hasn't already been
 			$affected_rows = \DB::update('widget_instance') // should be updated to 'widget_instance' upon implementation
 				->set([
@@ -312,6 +318,7 @@ class Widget_Instance
 					'attempts'      => $this->attempts,
 					'guest_access'  => Util_Validator::cast_to_bool_enum($this->guest_access),
 					'embedded_only' => Util_Validator::cast_to_bool_enum($this->embedded_only),
+					'published_by'  => $new_publisher,
 					'updated_at'    => time()
 				])
 				->where('id', $this->id)
@@ -432,6 +439,17 @@ class Widget_Instance
 	public function viewable_by($user_id)
 	{
 		return Perm_Manager::user_has_any_perm_to($user_id, $this->id, Perm::INSTANCE, [Perm::VISIBLE, Perm::FULL]);
+	}
+
+	/**
+	 * Checks if user can publish widget.
+	 *
+	 * @return bool Whether or not the current user can publish the widget
+	 */
+	public function publishable_by($user_id)
+	{
+		if ( ! $this->widget->restrict_publish) return true;
+		return ! Perm_Manager::is_student($user_id);
 	}
 
 	/**

--- a/fuel/app/classes/materia/widget/instance.php
+++ b/fuel/app/classes/materia/widget/instance.php
@@ -251,7 +251,7 @@ class Widget_Instance
 	{
 		// check for requirements
 		if ( ! $this->user_id > 0) return false;
-		if ( ! $this->is_draft && ! $this->publishable_by(\Model_User::find_current_id())) return false;
+		if ( ! $this->is_draft && ! $this->widget->publishable_by(\Model_User::find_current_id())) return false;
 
 		$is_new = ! Util_Validator::is_valid_hash($this->id);
 
@@ -439,17 +439,6 @@ class Widget_Instance
 	public function viewable_by($user_id)
 	{
 		return Perm_Manager::user_has_any_perm_to($user_id, $this->id, Perm::INSTANCE, [Perm::VISIBLE, Perm::FULL]);
-	}
-
-	/**
-	 * Checks if user can publish widget.
-	 *
-	 * @return bool Whether or not the current user can publish the widget
-	 */
-	public function publishable_by($user_id)
-	{
-		if ( ! $this->widget->restrict_publish) return true;
-		return ! Perm_Manager::is_student($user_id);
 	}
 
 	/**

--- a/fuel/app/classes/materia/widget/instance/manager.php
+++ b/fuel/app/classes/materia/widget/instance/manager.php
@@ -65,11 +65,11 @@ class Widget_Instance_Manager
 	}
 
 	/**
-	 * Checks to see if the given widget instance is locked for the current user.
+	 * Checks to see if the given widget instance is locked by the current user.
 	 *
 	 * @param inst_id widget instance id to check for lock
 	 *
-	 * @return bool whether the given instance is locked for the current user
+	 * @return bool whether the given instance is locked by the current user
 	 */
 	public static function locked_by_current_user(string $inst_id): bool
 	{

--- a/fuel/app/classes/materia/widget/instance/manager.php
+++ b/fuel/app/classes/materia/widget/instance/manager.php
@@ -65,6 +65,22 @@ class Widget_Instance_Manager
 	}
 
 	/**
+	 * Checks to see if the given widget instance is locked for the current user.
+	 *
+	 * @param inst_id widget instance id to check for lock
+	 *
+	 * @return bool whether the given instance is locked for the current user
+	 */
+	public static function locked_by_current_user($inst_id)
+	{
+		$me = \Model_User::find_current_id();
+		$locked_by = \Cache::easy_get('instance-lock.'.$inst_id);
+
+		if ( ! $locked_by) return true;
+		return $me && $locked_by == $me;
+	}
+
+	/**
 	 * Locks a widget instance for 2 minutes to prevent others from editing it.
 	 * Renew your locks by calling lock at least once per 2 minutes
 	 *

--- a/fuel/app/classes/materia/widget/instance/manager.php
+++ b/fuel/app/classes/materia/widget/instance/manager.php
@@ -71,7 +71,7 @@ class Widget_Instance_Manager
 	 *
 	 * @return bool whether the given instance is locked for the current user
 	 */
-	public static function locked_by_current_user($inst_id)
+	public static function locked_by_current_user(string $inst_id): bool
 	{
 		$me = \Model_User::find_current_id();
 		$locked_by = \Cache::easy_get('instance-lock.'.$inst_id);

--- a/fuel/app/classes/materia/widget/manager.php
+++ b/fuel/app/classes/materia/widget/manager.php
@@ -47,8 +47,6 @@ class Widget_Manager
 					break;
 			}
 
-			if ( ! \Service_User::verify_session(['basic_author', 'super_user'])) $query->where('author_only', '0');
-
 			$result = \DB::query($query)->execute();
 
 			$widget_ids = \Arr::flatten($result);

--- a/fuel/app/classes/materia/widget/manager.php
+++ b/fuel/app/classes/materia/widget/manager.php
@@ -47,6 +47,8 @@ class Widget_Manager
 					break;
 			}
 
+			if ( ! \Service_User::verify_session(['basic_author', 'super_user'])) $query->where('author_only', '0');
+
 			$result = \DB::query($query)->execute();
 
 			$widget_ids = \Arr::flatten($result);

--- a/fuel/app/migrations/044_add_author_only_to_widget.php
+++ b/fuel/app/migrations/044_add_author_only_to_widget.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Fuel\Migrations;
+
+class Add_author_only_to_widget
+{
+	public function up()
+	{
+		\DBUtil::add_fields('widget', array(
+			'author_only' => ['constraint' => "'0','1'", 'type' => 'enum'],
+		));
+	}
+
+	public function down()
+	{
+		\DBUtil::drop_fields('widget', array(
+			'author_only'
+		));
+	}
+}

--- a/fuel/app/migrations/044_add_restrict_publish_to_widget.php
+++ b/fuel/app/migrations/044_add_restrict_publish_to_widget.php
@@ -2,19 +2,19 @@
 
 namespace Fuel\Migrations;
 
-class Add_author_only_to_widget
+class Add_restrict_publish_to_widget
 {
 	public function up()
 	{
 		\DBUtil::add_fields('widget', array(
-			'author_only' => ['constraint' => "'0','1'", 'type' => 'enum'],
+			'restrict_publish' => ['constraint' => "'0','1'", 'type' => 'enum'],
 		));
 	}
 
 	public function down()
 	{
 		\DBUtil::drop_fields('widget', array(
-			'author_only'
+			'restrict_publish'
 		));
 	}
 }

--- a/fuel/app/migrations/045_add_published_by_to_widget_instance.php
+++ b/fuel/app/migrations/045_add_published_by_to_widget_instance.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Fuel\Migrations;
+
+class Add_published_by_to_widget_instance
+{
+	public function up()
+	{
+		\DBUtil::add_fields('widget_instance', array(
+			'published_by' => ['constraint' => 255, 'type' => 'bigint', 'unsigned' => true, 'null' => true]
+		));
+
+		//for each published widget instance, fill the new 'published_by' column with the creator of that instance
+		\DB::update('widget_instance')
+			->value('published_by', \DB::expr('user_id'))
+			->where('is_draft', '0')
+			->execute();
+	}
+
+	public function down()
+	{
+		\DBUtil::drop_fields('widget_instance', array(
+			'published_by'
+		));
+	}
+}

--- a/fuel/app/tests/api/v1.php
+++ b/fuel/app/tests/api/v1.php
@@ -550,40 +550,21 @@ class Test_Api_V1 extends \Basetest
 		//make sure we get an instance of a widget that restricts publish rights
 		$widget = $this->make_disposable_widget('RestrictPublish', true);
 
-		//get the author user's id for later
-		$author = $this->_as_author();
-
-		$this->_as_student();
-		$question = 'test';
-		$answer = 'test';
-		$qset = $this->create_new_qset($question, $answer);
-
-		$instance = Api_V1::widget_instance_new($widget->id, 'test', $qset, true);
-
-		//give author user access to the widget instance
-		$accessObj = new stdClass();
-		$accessObj->perms = [Perm::FULL => true];
-		$accessObj->expiration = null;
-		$accessObj->user_id = $author->id;
-		Api_V1::permissions_set(Perm::INSTANCE, $instance->id, [$accessObj]);
-
 		// ======= AS NO ONE ========
 		\Auth::logout();
-		$output = Api_V1::publish_verify($instance->id);
+		$output = Api_V1::publish_verify($widget->id);
 		$this->assertInstanceOf('\Materia\Msg', $output);
 		$this->assertEquals('Invalid Login', $output->title);
 
 		// ======= STUDENT ========
 		$this->_as_student();
-		$output = Api_V1::publish_verify($instance->id);
+		$output = Api_V1::publish_verify($widget->id);
 		$this->assertFalse($output);
 
 		// ======= AUTHOR ========
 		$this->_as_author();
-		$output = Api_V1::publish_verify($instance->id);
+		$output = Api_V1::publish_verify($widget->id);
 		$this->assertTrue($output);
-
-		Api_V1::widget_instance_delete($instance->id);
 	}
 
 	public function test_session_play_create()

--- a/fuel/app/tests/api/v1.php
+++ b/fuel/app/tests/api/v1.php
@@ -545,7 +545,7 @@ class Test_Api_V1 extends \Basetest
 		$this->assert_invalid_login_message($output);
 	}
 
-	public function test_widget_instance_edit_perms_verify()
+	public function test_widget_instance_edit_perms_verify(): void
 	{
 		//create a publish-restricted widget as a student and give an author full access to it
 		$widget = $this->make_disposable_widget('RestrictPublish', true);
@@ -605,7 +605,7 @@ class Test_Api_V1 extends \Basetest
 		$this->assertNull($output->msg);
 	}
 
-	public function test_widget_publish_perms_verify()
+	public function test_widget_publish_perms_verify(): void
 	{
 		//make sure we get an instance of a widget that restricts publish rights
 		$widget = $this->make_disposable_widget('RestrictPublish', true);

--- a/fuel/app/tests/api/v1.php
+++ b/fuel/app/tests/api/v1.php
@@ -545,6 +545,66 @@ class Test_Api_V1 extends \Basetest
 		$this->assert_invalid_login_message($output);
 	}
 
+	public function test_widget_instance_edit_perms_verify()
+	{
+		//create a publish-restricted widget as a student and give an author full access to it
+		$widget = $this->make_disposable_widget('RestrictPublish', true);
+
+		$author = $this->_as_author();
+
+		$this->_as_student();
+		$qset = $this->create_new_qset('question', 'answer');
+		$instance = Api_V1::widget_instance_new($widget->id, 'test', $qset, true);
+
+		$accessObj = new stdClass();
+		$accessObj->perms = [Perm::FULL => true];
+
+		$accessObj->expiration = null;
+		$accessObj->user_id = $author->id;
+		Api_V1::permissions_set(Perm::INSTANCE, $instance->id, [$accessObj]);
+
+		// ======= AS NO ONE ========
+		\Auth::logout();
+		$output = Api_V1::widget_instance_edit_perms_verify($instance->id);
+		trace($output);
+		$this->assertInstanceOf('\Materia\Msg', $output->msg);
+		$this->assertEquals('Invalid Login', $output->msg->title);
+		$this->assertTrue($output->is_locked);
+		$this->assertFalse($output->can_publish);
+
+		// ======= STUDENT ========
+		$this->_as_student();
+		$output = Api_V1::widget_instance_edit_perms_verify($instance->id);
+		$this->assertFalse($output->is_locked);
+		$this->assertFalse($output->can_publish);
+		$this->assertNull($output->msg);
+
+		// ======= AUTHOR ========
+		$this->_as_author();
+		$output = Api_V1::widget_instance_edit_perms_verify($instance->id);
+		$this->assertFalse($output->is_locked);
+		$this->assertTrue($output->can_publish);
+		$this->assertNull($output->msg);
+
+		// lock widget as author
+		Api_V1::widget_instance_lock($instance->id);
+
+		//check edit perms again
+		// ======= STUDENT ========
+		$this->_as_student();
+		$output = Api_V1::widget_instance_edit_perms_verify($instance->id);
+		$this->assertTrue($output->is_locked);
+		$this->assertFalse($output->can_publish);
+		$this->assertNull($output->msg);
+
+		// ======= AUTHOR ========
+		$this->_as_author();
+		$output = Api_V1::widget_instance_edit_perms_verify($instance->id);
+		$this->assertFalse($output->is_locked);
+		$this->assertTrue($output->can_publish);
+		$this->assertNull($output->msg);
+	}
+
 	public function test_widget_publish_perms_verify()
 	{
 		//make sure we get an instance of a widget that restricts publish rights

--- a/fuel/app/tests/api/v1.php
+++ b/fuel/app/tests/api/v1.php
@@ -199,7 +199,7 @@ class Test_Api_V1 extends \Basetest
 
 		$output = Api_V1::widget_instance_new($widget->id, 'test', $qset, false);
 		$this->assertInstanceOf('\Materia\Msg', $output);
-		$this->assertEquals('Widget can not be published by student!', $output->title);
+		$this->assertEquals('Widget type can not be published by students.', $output->title);
 	}
 
 	public function test_widget_instance_update()

--- a/fuel/app/tests/api/v1.php
+++ b/fuel/app/tests/api/v1.php
@@ -6,7 +6,6 @@ use \Materia\Api_V1;
  * @group Api
  * @group v1
  * @group Materia
- * @group Only
  */
 class Test_Api_V1 extends \Basetest
 {

--- a/fuel/app/tests/widgets/installer.php
+++ b/fuel/app/tests/widgets/installer.php
@@ -44,7 +44,7 @@ class Test_Widget_Installer extends \Basetest
 			'flash_version' => 3,
 			'height' => 55,
 			'width' => 100,
-			'author_only' => '0',
+			'restrict_publish' => '0',
 			'is_qset_encrypted' => '0',
 			'is_answer_encrypted' => '1',
 			'is_storage_enabled' => '1',

--- a/fuel/app/tests/widgets/installer.php
+++ b/fuel/app/tests/widgets/installer.php
@@ -44,6 +44,7 @@ class Test_Widget_Installer extends \Basetest
 			'flash_version' => 3,
 			'height' => 55,
 			'width' => 100,
+			'author_only' => '0',
 			'is_qset_encrypted' => '0',
 			'is_answer_encrypted' => '1',
 			'is_storage_enabled' => '1',

--- a/fuel/app/tests/widgets/instance.php
+++ b/fuel/app/tests/widgets/instance.php
@@ -63,20 +63,4 @@ class Test_Widget_Instance extends \Basetest
 		// make sure the new instance is different from the current demo
 		$this->assertNotEquals($inst_id, $duplicate->id);
 	}
-
-	public function test_publishable_by()
-	{
-		$widget = $this->make_disposable_widget('RestrictPublish', true);
-
-		$inst = new Widget_Instance(['widget' => $widget]);
-		$inst->db_get($widget->meta_data['demo'], false);
-
-		$student = $this->_as_student();
-		$output = $inst->publishable_by($student->id);
-		$this->assertFalse($output);
-
-		$author = $this->_as_author();
-		$output = $inst->publishable_by($author->id);
-		$this->assertTrue($output);
-	}
 }

--- a/fuel/app/tests/widgets/instance.php
+++ b/fuel/app/tests/widgets/instance.php
@@ -31,6 +31,7 @@ class Test_Widget_Instance extends \Basetest
 			'guest_access'    => 0,
 			'is_student_made' => 1,
 			'widget'          => $widget,
+			'published_by'    => 1
 		];
 
 
@@ -63,5 +64,19 @@ class Test_Widget_Instance extends \Basetest
 		$this->assertNotEquals($inst_id, $duplicate->id);
 	}
 
+	public function test_publishable_by()
+	{
+		$widget = $this->make_disposable_widget('RestrictPublish', true);
 
+		$inst = new Widget_Instance(['widget' => $widget]);
+		$inst->db_get($widget->meta_data['demo'], false);
+
+		$student = $this->_as_student();
+		$output = $inst->publishable_by($student->id);
+		$this->assertFalse($output);
+
+		$author = $this->_as_author();
+		$output = $inst->publishable_by($author->id);
+		$this->assertTrue($output);
+	}
 }

--- a/fuel/app/tests/widgets/widget.php
+++ b/fuel/app/tests/widgets/widget.php
@@ -7,7 +7,7 @@
 
 class Test_Widget extends \Basetest
 {
-	public function test_publishable_by()
+	public function test_publishable_by(): void
 	{
 		$widget = $this->make_disposable_widget('RestrictPublish', true);
 

--- a/fuel/app/tests/widgets/widget.php
+++ b/fuel/app/tests/widgets/widget.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @group App
+ * @group Widget
+ * @group Materia
+ */
+
+class Test_Widget extends \Basetest
+{
+	public function test_publishable_by()
+	{
+		$widget = $this->make_disposable_widget('RestrictPublish', true);
+
+		$student = $this->_as_student();
+		$output = $widget->publishable_by($student->id);
+		$this->assertFalse($output);
+
+		$author = $this->_as_author();
+		$output = $widget->publishable_by($author->id);
+		$this->assertTrue($output);
+	}
+}

--- a/fuel/app/themes/default/partials/my_widgets.php
+++ b/fuel/app/themes/default/partials/my_widgets.php
@@ -244,8 +244,8 @@
 						</ul>
 						<ul class="options">
 							<li class="share"><div class="link" ng-click="showCollaboration()" ng-class="{'disabled' : perms.stale}">Collaborate{{ collaborateCount }}</div></li>
-							<li class="copy" ng-class="{'disabled' : selected.accessLevel == 0}"><div class="link" id="copy_widget_link" ng-class="{'disabled' : selected.accessLevel == 0}" ng-click="showCopyDialog()">Make a Copy</div></li>
-							<li class="delete" ng-class="{'disabled' : selected.accessLevel == 0}"><div class="link" id="delete_widget_link" ng-class="{'disabled' : selected.accessLevel == 0}" ng-click="showDelete()">Delete</div></li>
+							<li class="copy" ng-class="{'disabled' : selected.accessLevel != 30}"><div class="link" id="copy_widget_link" ng-class="{'disabled' : selected.accessLevel != 30}" ng-click="showCopyDialog()">Make a Copy</div></li>
+							<li class="delete" ng-class="{'disabled' : selected.accessLevel != 30}"><div class="link" id="delete_widget_link" ng-class="{'disabled' : selected.accessLevel != 30}" ng-click="showDelete()">Delete</div></li>
 						</ul>
 						<div class="delete_dialogue" ng-show="show.deleteDialog">
 							<span class="delete-warning">Are you sure you want to delete this widget?</span>

--- a/fuel/app/themes/default/partials/my_widgets.php
+++ b/fuel/app/themes/default/partials/my_widgets.php
@@ -4,7 +4,7 @@
 		<div ng-controller="SelectedWidgetController">
 			<!-- standard post-publish warning for users who can publish this widget -->
 			<modal-dialog class="edit-published-widget"
-				show="show.editPublishedWarning && canPublish"
+				show="show.editPublishedWarning"
 				dialog-title="Warning About Editing Published Widgets:"
 				width="600px" height="320px">
 				<div class="container">
@@ -26,7 +26,7 @@
 
 			<!-- post-publish warning for users who can not publish this widget -->
 			<modal-dialog class="edit-published-widget"
-				show="show.editPublishedWarning && !canPublish"
+				show="show.restrictedPublishWarning"
 				dialog-title="Unable to Edit Published Widget:"
 				width="600px" height="170px">
 				<div class="container">

--- a/fuel/app/themes/default/partials/my_widgets.php
+++ b/fuel/app/themes/default/partials/my_widgets.php
@@ -34,7 +34,7 @@
 					<p>You are not able to publish this widget or make any changes to it after it has been published.</p>
 
 					<span class="center">
-						<a class="cancel_button" href="javascript:;" ng-click="show.editPublishedWarning = false">Cancel</a>
+						<a class="cancel_button" href="javascript:;" ng-click="show.restrictedPublishWarning = false">Cancel</a>
 					</span>
 				</div>
 			</modal-dialog>

--- a/fuel/app/themes/default/partials/my_widgets.php
+++ b/fuel/app/themes/default/partials/my_widgets.php
@@ -2,7 +2,11 @@
 	<div class="qtip top nowidgets" ng-show="widgets.widgetList.length == 0">Click here to start making a new widget!</div>
 	<div class="container">
 		<div ng-controller="SelectedWidgetController">
-			<modal-dialog class="edit-published-widget" show="show.editPublishedWarning" dialog-title="Warning About Editing Published Widgets:" width="600px" height="320px">
+			<!-- standard post-publish warning for users who can publish this widget -->
+			<modal-dialog class="edit-published-widget"
+				show="show.editPublishedWarning && canPublish"
+				dialog-title="Warning About Editing Published Widgets:"
+				width="600px" height="320px">
 				<div class="container">
 					<p>Editing a published widget may affect statistical analysis when comparing data collected prior to your edits.</p>
 					<h3>Caution should be taken when:</h3>
@@ -16,6 +20,21 @@
 					<span class="center">
 						<a class="cancel_button" href="javascript:;" ng-click="show.editPublishedWarning = false">Cancel</a>
 						<a class="action_button green" ng-href="{{selected.edit}}">Edit Published Widget</a>
+					</span>
+				</div>
+			</modal-dialog>
+
+			<!-- post-publish warning for users who can not publish this widget -->
+			<modal-dialog class="edit-published-widget"
+				show="show.editPublishedWarning && !canPublish"
+				dialog-title="Unable to Edit Published Widget:"
+				width="600px" height="170px">
+				<div class="container">
+					<h3>This widget is restricted.</h3>
+					<p>You are not able to publish this widget or make any changes to it after it has been published.</p>
+
+					<span class="center">
+						<a class="cancel_button" href="javascript:;" ng-click="show.editPublishedWarning = false">Cancel</a>
 					</span>
 				</div>
 			</modal-dialog>
@@ -62,6 +81,7 @@
 								<div class="options" >
 									<span class="owner">Full</span>
 									<span class="undo">Removed <a href="#">Undo</a></span>
+
 									<select ng-disabled="selected.shareable==false" tabindex="0" id="perm" class="perm" ng-model="collaborator.access" ng-change="checkForWarning(collaborator)">
 										<option value={{ACCESS.FULL}} ng-selected="collaborator.access == ACCESS.FULL" >Full</option>
 										<option value={{ACCESS.VISIBLE}} ng-selected="collaborator.access == ACCESS.VISIBLE" >View Scores</option>

--- a/fuel/app/themes/default/partials/widget/create.php
+++ b/fuel/app/themes/default/partials/widget/create.php
@@ -18,7 +18,8 @@
 			</div>
 		</div>
 
-		<div class="publish animate-show" ng-show="popup == 'publish'">
+		<!-- standard pre-publish confirmation dialog -->
+		<div class="publish animate-show" ng-show="popup == 'publish' && canPublish">
 			<h1>Publish Widget</h1>
 			<p>Publishing removes the "Draft" status of a widget, which grants you the ability to use it in your course and collect student scores &amp; data.</p>
 			<div class="publish_container">
@@ -27,10 +28,26 @@
 			</div>
 		</div>
 
+		<!-- warning when current user can't publish widget -->
+		<div class="publish animate-show" ng-show="popup == 'publish' && !canPublish">
+			<h1>Publish Restricted</h1>
+			<p>Only authors are able to publish this widget.</p>
+			<p>In order for this widget to be published, it must first be shared with an author.</p>
+
+			<div class="publish_container">
+				<a class="cancel_button" ng-click="cancelPublish()">Cancel</a>
+			</div>
+		</div>
+
 		<section id="action-bar" ng-show="showActionBar">
 			<a id="returnLink" href="{{ returnUrl }}">&larr;Return to {{ returnPlace }}</a>
 			<a id="importLink" ng-click="showQuestionImporter()">Import Questions...</a>
-			<button id="creatorPublishBtn" class="edit_button green" type="button" ng-click="onPublishPressed()">{{ publishText }}</button>
+			<button id="creatorPublishBtn"
+				class="edit_button green"
+				type="button"
+				ng-click="onPublishPressed()">
+				{{ publishText }}
+			</button>
 			<span ng-hide="updateMode || nonEditable">
 				<div class="dot"></div>
 				<button id="creatorPreviewBtn" class="edit_button orange" type="button" ng-click="requestSave('preview')"><span>{{ previewText }}</span></button>

--- a/fuel/app/themes/default/partials/widget/create.php
+++ b/fuel/app/themes/default/partials/widget/create.php
@@ -31,7 +31,7 @@
 		<!-- warning when current user can't publish widget -->
 		<div class="publish animate-show" ng-show="popup == 'publish' && !canPublish">
 			<h1>Publish Restricted</h1>
-			<p>Only authors are able to publish this widget.</p>
+			<p>Students are not allowed to publish this widget type.</p>
 			<p>In order for this widget to be published, it must first be shared with an author.</p>
 
 			<div class="publish_container">

--- a/fuel/app/themes/default/partials/widget/create.php
+++ b/fuel/app/themes/default/partials/widget/create.php
@@ -32,7 +32,7 @@
 		<div class="publish animate-show" ng-show="popup == 'publish' && !canPublish">
 			<h1>Publish Restricted</h1>
 			<p>Students are not allowed to publish this widget type.</p>
-			<p>In order for this widget to be published, it must first be shared with an author.</p>
+			<p>Add a non-student as a collaborator, they must authorize and publish it for you.</p>
 
 			<div class="publish_container">
 				<a class="cancel_button" ng-click="cancelPublish()">Cancel</a>


### PR DESCRIPTION
Closes #1202.

Relies on #1199.

Adjusts some communications between the front and back ends to determine who can edit widget instances and when.