### PR TITLE
adds post event messages so apps containing materia can listen in

### DIFF
--- a/src/coffee/materia/materia.enginecore.coffee
+++ b/src/coffee/materia/materia.enginecore.coffee
@@ -75,6 +75,9 @@ Namespace('Materia').Engine = do ->
 
 	escapeScriptTags = (text) ->
 		text.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+	
+	postMessage = (message) ->
+		_sendPostMessage 'postMessage', message
 
 	start:start
 	addLog:addLog
@@ -86,3 +89,4 @@ Namespace('Materia').Engine = do ->
 	disableResizeInterval:disableResizeInterval
 	setHeight:setHeight # allows the widget to resize its iframe container to fit the height of its contents
 	escapeScriptTags:escapeScriptTags
+	postMessage: postMessage


### PR DESCRIPTION
This has bearing on what Obojobo can do when listening to Materia.  Keep in mind this is already being used for scores in Obojobo Classic, but Obojobo Next could use greater insight by listening to the messages.

Worth noting these post messages aren't super secure, mostly useful for state change information.  Score information or user authenticity should be cryptographically signed to fully trust it.