### PR TITLE
Allow widgets to save their current play state so a play can be resumed later.

### DIFF
--- a/fuel/app/classes/controller/widgets.php
+++ b/fuel/app/classes/controller/widgets.php
@@ -343,6 +343,7 @@ class Controller_Widgets extends Controller
 
 		// create the play
 		$play_id = \Materia\Api::session_play_create($inst_id, $context_id);
+		$play_state = \Materia\Session_Play::get_play_state($play_id) ?: '';
 
 		if ($play_id instanceof \Materia\Msg)
 		{
@@ -350,7 +351,7 @@ class Controller_Widgets extends Controller
 			throw new HttpServerErrorException;
 		}
 
-		$this->display_widget($inst, $play_id, $is_embedded);
+		$this->display_widget($inst, $play_id, $is_embedded, $play_state);
 	}
 
 	/**
@@ -456,7 +457,7 @@ class Controller_Widgets extends Controller
 		return [$summary, $desc, $status['open']];
 	}
 
-	protected function display_widget(\Materia\Widget_Instance $inst, $play_id=false, $is_embedded=false)
+	protected function display_widget(\Materia\Widget_Instance $inst, $play_id=false, $is_embedded=false, $play_state=null)
 	{
 		Css::push_group(['core', 'widget_play']);
 		Js::push_group(['angular', 'materia', 'student']);
@@ -467,6 +468,7 @@ class Controller_Widgets extends Controller
 		}
 
 		Js::push_inline('var PLAY_ID = "'.$play_id.'";');
+		Js::push_inline("var PLAY_STATE = '".$play_state."';");
 		$this->add_s3_config_to_response();
 		$this->theme->get_template()
 			->set('title', $inst->name.' '.$inst->widget->name)

--- a/fuel/app/classes/materia/api/v1.php
+++ b/fuel/app/classes/materia/api/v1.php
@@ -385,12 +385,27 @@ class Api_V1
 		// but we don't want to include that in the results
 		$play  = new Session_Play();
 		$plays = $play->get_plays_by_user_id(\Model_User::find_current_id(), $start, $range + 1);
+		trace($plays);
 		$count = count($plays);
 		if ($count > $range) $plays = array_slice($plays, 0, $range);
 		return [
 			'activity' => $plays,
 			'more'     => $count > $range
 		];
+	}
+
+	static public function play_state_save($play_id, $state)
+	{
+		$inst = self::_get_instance_for_play_id($play_id);
+		if ( ! $inst->playable_by_current_user()) return Msg::no_login();
+		if ($inst->guest_access) return;
+
+		$encoded_state = base64_encode(json_encode($state));
+
+		\DB::update('log_play')
+			->value('last_state', $encoded_state)
+			->where('id', $play_id)
+			->execute();
 	}
 
 	static public function play_logs_save($play_id, $logs, $preview_inst_id = null)

--- a/fuel/app/migrations/040_add_play_state_to_log_play.php
+++ b/fuel/app/migrations/040_add_play_state_to_log_play.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Fuel\Migrations;
+
+class Add_Play_State_To_Log_Play
+{
+	public function up()
+	{
+		\DBUtil::add_fields(
+			'log_play',
+			[
+				'last_state' => ['type' => 'longblob'],
+			]
+		);
+	}
+
+	public function down()
+	{
+		\DBUtil::drop_fields('log_play', ['last_state']);
+	}
+}


### PR DESCRIPTION
Adds support to Materia platform to receive and save play states from widgets, and recall those states when a user tries to play the same widget prior to completing it.