### PR TITLE
Check for player and creator guides before making links to them.

### DIFF
--- a/fuel/app/classes/controller/widgets.php
+++ b/fuel/app/classes/controller/widgets.php
@@ -128,6 +128,8 @@ class Controller_Widgets extends Controller
 		$this->theme->set_partial('content', 'partials/widget/guide_doc')
 			->set('name', $widget->name)
 			->set('type', $type)
+			->set('has_player_guide', ! empty($widget->player_guide))
+			->set('has_creator_guide', ! empty($widget->creator_guide))
 			->set('doc_path', Config::get('materia.urls.engines').$widget->dir.$guide);
 	}
 

--- a/fuel/app/themes/default/partials/widget/guide_doc.php
+++ b/fuel/app/themes/default/partials/widget/guide_doc.php
@@ -2,8 +2,12 @@
 	<div id="top">
 		<h1><?= $name ?></h1>
 		<div id="guide-tabs" class="<?= $type ?>-guide">
+			<? if ($has_player_guide): ?>
 			<a href="./players-guide">Player Guide</a>
+			<? endif; ?>
+			<? if ($has_creator_guide): ?>
 			<a href="./creators-guide">Creator Guide</a>
+			<? endif; ?>
 		</div>
 	</div>
 	<div id="guide-container">


### PR DESCRIPTION
Closes #1249.

Adjusts controller for guide page to only include links for guides that the widget actually has.