### PR TITLE
participation score passback

### DIFF
--- a/fuel/app/classes/materia/api/v1.php
+++ b/fuel/app/classes/materia/api/v1.php
@@ -494,6 +494,19 @@ class Api_V1
 				return new Msg(Msg::ERROR, 'Timing validation error.', true);
 			}
 
+			// if widget is not scorable, check for a participation score log
+			// if one is found, use it as a "score" event for LTI passback
+			if ( ! $inst->widget->is_scorable)
+			{
+				foreach ($logs as $log)
+				{	
+					if (Session_Logger::get_type($log['type']) == Session_Log::TYPE_UNSCORABLE)
+					{
+						\Event::trigger('score_updated', [$play->id, $play->inst_id, $play->user_id, $log['value'], 100], 'string');
+					}
+				}
+			}
+
 			// validate the scores the game generated on the server
 			try
 			{

--- a/fuel/app/classes/materia/api/v1.php
+++ b/fuel/app/classes/materia/api/v1.php
@@ -499,7 +499,7 @@ class Api_V1
 			if ( ! $inst->widget->is_scorable)
 			{
 				foreach ($logs as $log)
-				{	
+				{
 					if (Session_Logger::get_type($log['type']) == Session_Log::TYPE_UNSCORABLE)
 					{
 						\Event::trigger('score_updated', [$play->id, $play->inst_id, $play->user_id, $log['value'], 100], 'string');


### PR DESCRIPTION
Adds a check in `play_logs_save` for whether a widget is unscored, and if so, if a participation score is included in the logs. If one is found, it broadcasts the `score_updated` event for LTI passback.

I'm not really sure if this is 100% the best implementation or if there is a better location for this, but there didn't seem like a better location downstream of the API where that might better occur.