### PR TITLE
# 1066 Add inline info about previewing widgets and student view

### DIFF
--- a/fuel/app/themes/default/lti/partials/open_preview.php
+++ b/fuel/app/themes/default/lti/partials/open_preview.php
@@ -11,6 +11,6 @@
 
 	<div class="help-container">
 		<p>You can preview the widget if you have access to it.</p>
-		<p>To view the widget in Canvas as a student, view the assignment while in Student View. <a href="https://community.canvaslms.com/docs/DOC-13122-415261153" target="_blank" class="external">See how!</a></p>
+		<p>To view the widget in Canvas as a student, view the assignment while in <a href="https://webcourses.ucf.edu/profile/settings" target="_blank" class="external">Student View</a>.</p>
 	</div>
 </section>

--- a/fuel/app/themes/default/lti/partials/open_preview.php
+++ b/fuel/app/themes/default/lti/partials/open_preview.php
@@ -8,4 +8,9 @@
 		<p>Students will see the widget instead of this message.</p>
 		<a target="_blank" class="button" href="<?= $preview_url ?>">Preview widget in new tab</a>
 	</div>
+
+	<div class="help-container">
+		<p>You can preview the widget if you have access to it.</p>
+		<p>To view the widget in Canvas as a student, view the assignment while in Student View. <a href="https://community.canvaslms.com/docs/DOC-13122-415261153" target="_blank" class="external">See how!</a></p>
+	</div>
 </section>


### PR DESCRIPTION
- Add blurb about needing access to view widgets
- Add blurb about viewing in student view with link

Needs my [Materia Server Client Assets PR](https://github.com/ucfopen/Materia-Server-Client-Assets/pull/90) for styling.

For #1066 

This is the lazy way that doesn't try to add temporary permissions or check if they have permissions. Currently it links to the Canvas settings page for student view but I think this could also link to instructions on how to switch to student view.