### PR TITLE
Add additional warning/context to the widget admin panel when running on Heroku.

### DIFF
--- a/fuel/app/classes/controller/admin.php
+++ b/fuel/app/classes/controller/admin.php
@@ -25,7 +25,8 @@ class Controller_Admin extends Controller
 		$this->theme->get_template()->set('title', 'Widget Admin');
 		$this->theme->set_partial('footer', 'partials/angular_alert');
 		$this->theme->set_partial('content', 'partials/admin/widget')
-			->set('upload_enabled', Config::get('materia.enable_admin_uploader', false));
+			->set('upload_enabled', Config::get('materia.enable_admin_uploader', false))
+			->set('heroku_warning', Config::get('materia.heroku_admin_warning', false));
 	}
 
 	public function get_user()

--- a/fuel/app/config/heroku/materia.php
+++ b/fuel/app/config/heroku/materia.php
@@ -11,6 +11,11 @@ return [
 	* like S3 (see docs)
 	*/
 	'enable_admin_uploader' => false,
+	/**
+	* Add a Heroku-only warning to appear on the
+	* admin panel explaining Heroku-only limitations
+	*/
+	'heroku_admin_warning' => true,
 
 	// Asset storage configuration
 	'asset_storage_driver' => 'db',

--- a/fuel/app/themes/default/partials/admin/widget.php
+++ b/fuel/app/themes/default/partials/admin/widget.php
@@ -21,8 +21,19 @@
 				<p>Browse installable widgets on <a href="https://ucfopen.github.io/materia-widget-gallery/" target="_blank" rel="noopener noreferrer">The Official Materia Widget Gallery</a></p>
 				<p>Browse features and more on <a href="https://ucfopen.github.io/Materia-Docs/" target="_blank" rel="noopener noreferrer">The Official Materia Documentation Page</a></p>
 			<?php else: ?>
-				<p>Widget uploader is <em>disabled</em></p>
+				<p>Widget uploader is <em>disabled</em>.</p>
 				<p>To enable, alter the "enable_admin_uploader" configuration option in config/materia.php.</p>
+				<?php if ($heroku_warning): ?>
+				<p>
+					Due to Heroku the temporary nature of Heroku servers, any widgets installed after the server
+					is spun up will not be available after the server spins down again. Read more at
+					<a href="https://ucfopen.github.io/Materia-Docs/admin/heroku.html#installing-widgets"
+						target="_blank"
+						rel="noopener noreferrer">
+						The Official Materia Documentation Page.
+					</a>
+				</p>
+				<?php endif; ?>
 			<?php endif ?>
 		</section>
 	</div>


### PR DESCRIPTION
Closes #1276.

Added a check for a config variable only set in the Heroku override config files, and an associated extra warning message that should only appear if Materia is being run in Heroku (assuming the config isn't overridden or somehow unused).