### PR TITLE
[fix] notification email from system user working

### DIFF
--- a/fuel/app/classes/materia/perm/manager.php
+++ b/fuel/app/classes/materia/perm/manager.php
@@ -708,7 +708,7 @@ class Perm_Manager
 		foreach ($results as $r)
 		{
 			\Model_Notification::send_item_notification(
-				0,
+				0, // 'from' user is Materia
 				$r['user_id'],
 				$r['object_type'],
 				$r['object_id'],

--- a/fuel/app/migrations/050_purge_expired_object_perms.php
+++ b/fuel/app/migrations/050_purge_expired_object_perms.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Fuel\Migrations;
+
+class Purge_expired_object_perms
+{
+	public function up()
+	{
+        // Materia now sends out notifications when your permissions expire & are deleted
+        // Prior to 7.0.0, this was handled differently, so we never purged the expired perms
+        // Post 7.0.0 we do, so this is to prevent the first runs after upgrading from
+        // sending out hundreds of emails
+		\DB::delete('perm_object_to_user')
+			->where('expires_at', '<=', time())
+			->execute();
+	}
+
+	public function down()
+	{
+		// nothing to do
+	}
+}

--- a/fuel/app/tests/model/notification.php
+++ b/fuel/app/tests/model/notification.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @group App
+ * @group Model
+ * @group Notification
+ * @group Materia
+ */
+
+class Test_Model_Notification extends \Basetest
+{
+
+	public function test_get_user_or_system()
+	{
+        $user = $this->make_random_author();
+        $result = \Model_Notification::get_user_or_system($user->id);
+        $this->assertEquals($result->id, $user->id);
+        $this->assertEquals($result->first, $user->first);
+        $this->assertEquals($result->last, $user->last);
+        $this->assertEquals($result->username, $user->username);
+	}
+
+	public function test_get_user_or_system_when_zero()
+	{
+        // 0 indicates the 'from' user is the server
+        $user = $this->make_random_author();
+        $result = \Model_Notification::get_user_or_system(0);
+        $this->assertEquals($result->first, 'Materia');
+        $this->assertEquals($result->last, '');
+        $this->assertEquals($result->username, 'Server');
+        $this->assertEquals($result->email, \Config::get('materia.system_email'));
+	}
+
+}


### PR DESCRIPTION
Changes in 7.0.0 changed how object permissions expirations were
handled.  It now purges all old permissions and notifies before checking
for access.  This require notifications to be sent by the server instead
of a specific user. Due to an oversight, lack of testing, and a dev env
that has email disabled - the code that actually sends the mail did not
receive associated updates that it needed.

This solves the problem by extracting the code that resolves the from
user for notifications so it can be used in both places.

This code also changes notifications so that when one is sent, no longer
are all pending notifications sent.  This change was made to prevent old
notifications that have gone unsent from potentially causing errors in
unrelated code (if a bug occurs in sending a notification, it will keep
occuring - blocking other notifications).

This means we no longer have code that will send past failed notifications.