### PR TITLE
adds a git user prior to running run_build_github_release_package

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,6 +13,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      # run_build_github_release_package.sh relies on the current git user info
+      - run: git config --global user.email "lst@ucf.edu"
+      - run: git config --global user.name "ucfcdl-robot"
+
       - name: Build Packages
         run: cd docker && ./run_build_github_release_package.sh
 


### PR DESCRIPTION
The github action for building a release wants to include the user info for the current git user, this sets that info prior to the script trying to get it.