### PR TITLE
Hotfix to correct local test failure

### DIFF
--- a/docker/docker-compose.override.test.yml
+++ b/docker/docker-compose.override.test.yml
@@ -31,8 +31,8 @@ services:
       - MYSQL_USER
       - MYSQL_PASSWORD
       - MYSQL_DATABASE=test
-    volumes:
-      - "./config/mysql/dev.my.cnf:/etc/mysql/conf.d/my.cnf"
+    # volumes:
+    #   - "./config/mysql/dev.my.cnf:/etc/mysql/conf.d/my.cnf"
     # this makes the unit tests much faster but it's a little weird jumping
     # back and forth between running the server and testing
     # tmpfs:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -62,6 +62,8 @@ services:
       - "3306:3306" # allow mysql access from the host - use /etc/hosts to set mysql to your docker-machine ip
     networks:
       - backend
+    volumes:
+      - "./config/mysql/01_create_test.sql:/docker-entrypoint-initdb.d/01_create_test.sql"
 
   memcached:
     image: memcached:1.6.6-alpine


### PR DESCRIPTION
The recent docker changes had a side effect of no longer creating an empty test database alongside the primary materia database for the purposes of running unit tests. This re-implements the sql query that's run when the mysql container is created, pending a more thorough solution.