### PR TITLE
Show owners for LTI embedded widgets to instructors who don't own them.

### DIFF
--- a/fuel/app/classes/materia/widget/instance.php
+++ b/fuel/app/classes/materia/widget/instance.php
@@ -473,6 +473,22 @@ class Widget_Instance
 		return $duplicate;
 	}
 
+	public function get_owners()
+	{
+		$all_users_with_perms = \Materia\Perm_Manager::get_all_users_with_perms_to($this->id, Perm::INSTANCE);
+		$owners = [];
+		$current_timestamp = time();
+		foreach ($all_users_with_perms as $user_id => $perm)
+		{
+			$not_expired = $perm[1] ? $perm[1] > $current_timestamp : true;
+			if ($perm[0] == \Materia\Perm::FULL && $not_expired)
+			{
+				$owners[] = \Model_User::find_by_id($user_id);
+			}
+		}
+		return $owners;
+	}
+
 	/**
 	 * a convienent way to set the perms of this widget
 	 *

--- a/fuel/app/classes/model/user.php
+++ b/fuel/app/classes/model/user.php
@@ -68,6 +68,13 @@ class Model_User extends Orm\Model
 		return $array[1];
 	}
 
+	public static function find_by_id($id)
+	{
+		return \Model_User::query()
+			->where('id', $id)
+			->get_one();
+	}
+
 	public static function find_by_username($username)
 	{
 		return \Model_User::query()

--- a/fuel/app/modules/lti/classes/controller/lti.php
+++ b/fuel/app/modules/lti/classes/controller/lti.php
@@ -114,6 +114,10 @@ class Controller_Lti extends \Controller
 	{
 		$inst = \Materia\Widget_Instance_Manager::get($inst_id);
 
+		// If the current user does not have ownership over the embedded widget, find all of the users who do
+		$current_user_owns = \Materia\Perm_Manager::user_has_any_perm_to(\Model_User::find_current_id(), $inst_id, \Materia\Perm::INSTANCE, [\Materia\Perm::FULL]);
+		$instance_owner_list = $current_user_owns ? [] : $inst->get_owners();
+
 		$this->theme->set_template('layouts/main')
 			->set('title', 'Widget Connected Successfully')
 			->set('page_type', 'preview');
@@ -123,7 +127,9 @@ class Controller_Lti extends \Controller
 			->set('widget_name', $inst->widget->name)
 			->set('preview_url', \Uri::create('/preview/'.$inst_id))
 			->set('icon', \Config::get('materia.urls.engines')."{$inst->widget->dir}img/icon-92.png")
-			->set('preview_embed_url', \Uri::create('/preview-embed/'.$inst_id));
+			->set('preview_embed_url', \Uri::create('/preview-embed/'.$inst_id))
+			->set('current_user_owns', $current_user_owns)
+			->set('instance_owner_list', $instance_owner_list);
 
 		$this->insert_analytics();
 

--- a/fuel/app/themes/default/lti/layouts/test_provider.php
+++ b/fuel/app/themes/default/lti/layouts/test_provider.php
@@ -213,7 +213,7 @@
 				One of the advantages of this method is the signature is generated and timestamped
 				when you click the button.  The other buttons on this page build the signature and timestamp
 				when the page is loaded - so they can easily expire
-			 -->
+			-->
 
 			<form onsubmit="setLtiUrl(this)" method="POST" target="embed_iframe" action="<?= $learner_endpoint ?>" >
 				<input type="hidden" class="lti_url" name="lti_url" />
@@ -268,6 +268,15 @@
 				<input type="submit" id="play_as_instructor" value="As Instructor">
 			</form>
 
+			<form onsubmit="setLtiUrl(this)" method="POST" target="embed_iframe" action="<?= $learner_endpoint ?>" >
+				<input type="hidden" class="lti_url" name="lti_url" />
+				<input type="hidden" class="context_id" name="context_id" />
+				<input type="hidden" class="resource_link" name="resource_link" />
+				<input type="hidden" class="custom_widget_instance_id" name="custom_widget_instance_id" />
+				<input type="hidden" id="as_instructor2" name="as_instructor2" value="as_instructor2" />
+				<input type="submit" id="play_as_instructor2" value="As New Instructor">
+			</form>
+
 			<hr />
 			<h2>Other</h2>
 
@@ -284,7 +293,7 @@
 					<? if($name == 'oauth_signature') : ?>
 						<?= \Form::hidden('oauth_signature', 'THIS_WILL_FAIL') ?>
 					<? else: ?>
-					 	<?= \Form::hidden($name, $value) ?>
+						<?= \Form::hidden($name, $value) ?>
 					<? endif ?>
 				<?php endforeach ?>
 				<input type="submit" value="Test Validation (bad signature)">

--- a/fuel/app/themes/default/lti/partials/open_preview.php
+++ b/fuel/app/themes/default/lti/partials/open_preview.php
@@ -3,6 +3,23 @@
 	<div id="logo"></div>
 </header>
 <section>
+	<?php if(!$current_user_owns): ?>
+		<div class="help-container">
+			<p>You don't own this widget!</p>
+			<p>Please contact one of the widget owners listed below to request access to this widget:</p>
+			<ul>
+				<?php foreach($instance_owner_list as $owner):?>
+					<li>
+						<a href=<?= 'mailto:'.$owner->email ?>>
+							<?= $owner->first.' '.$owner->last ?>
+							(<?= $owner->email ?>)
+						</a>
+					</li>
+				<?php endforeach; ?>
+			</ul>
+		</div>
+	<?php endif; ?>
+
 	<div class="container">
 		<div class="widget_info">
 			<div class="widget_icon">


### PR DESCRIPTION
Closes #1318.
When viewing an embedded widget as an instructor, the page will now indicate if the current user does not own the embedded widget and list users who have ownership permissions.