### PR TITLE
Access Request option for LTI previews

### DIFF
--- a/fuel/app/classes/controller/api/instance.php
+++ b/fuel/app/classes/controller/api/instance.php
@@ -28,4 +28,12 @@ class Controller_Api_Instance extends Controller_Rest
 
 		return $this->response($history, 200);
 	}
+
+	public function post_request_access()
+	{
+		$user_id = \Model_User::find_current_id();
+		$inst_id = Input::post('inst_id', null);
+		$owner_id = Input::post('owner_id', null);
+		\Model_Notification::send_item_notification($user_id, $owner_id, \Materia\Perm::INSTANCE, $inst_id, 'access_request', \Materia\Perm::FULL);
+	}
 }

--- a/fuel/app/classes/materia/widget/instance.php
+++ b/fuel/app/classes/materia/widget/instance.php
@@ -473,6 +473,22 @@ class Widget_Instance
 		return $duplicate;
 	}
 
+	public function get_owners()
+	{
+		$all_users_with_perms = \Materia\Perm_Manager::get_all_users_with_perms_to($this->id, Perm::INSTANCE);
+		$owners = [];
+		$current_timestamp = time();
+		foreach ($all_users_with_perms as $user_id => $perm)
+		{
+			$not_expired = $perm[1] ? $perm[1] > $current_timestamp : true;
+			if ($perm[0] == \Materia\Perm::FULL && $not_expired)
+			{
+				$owners[] = \Model_User::find_by_id($user_id);
+			}
+		}
+		return $owners;
+	}
+
 	/**
 	 * a convienent way to set the perms of this widget
 	 *

--- a/fuel/app/classes/model/notification.php
+++ b/fuel/app/classes/model/notification.php
@@ -17,6 +17,7 @@ class Model_Notification extends \Orm\Model
 		'avatar',
 		'created_at',
 		'updated_at',
+		'action'
 	];
 
 	protected static $_observers = [
@@ -77,6 +78,8 @@ class Model_Notification extends \Orm\Model
 				$widget_name = $inst->name;
 				$widget_type = $inst->widget->name;
 
+				$action = '';
+
 				switch ($new_perm)
 				{
 					case \Materia\Perm::FULL:
@@ -106,6 +109,11 @@ class Model_Notification extends \Orm\Model
 						$subject = "<b>$user_link deleted $widget_type widget \"$widget_name\".</b>";
 						break;
 
+					case 'access_request':
+						$subject = "<b>$user_link is requesting access to your widget \"$widget_name\".</b><br /> The widget is currently being used within a course in your LMS.";
+						$action = 'access_request';
+						break;
+
 					default:
 						return false;
 				}
@@ -126,6 +134,7 @@ class Model_Notification extends \Orm\Model
 			'is_read'       => '0',
 			'subject'       => $subject,
 			'avatar'        => \Materia\Utils::get_avatar(50),
+			'action'        => $action
 		]);
 
 		$notification->save();

--- a/fuel/app/classes/model/user.php
+++ b/fuel/app/classes/model/user.php
@@ -68,6 +68,13 @@ class Model_User extends Orm\Model
 		return $array[1];
 	}
 
+	public static function find_by_id($id)
+	{
+		return \Model_User::query()
+			->where('id', $id)
+			->get_one();
+	}
+
 	public static function find_by_username($username)
 	{
 		return \Model_User::query()

--- a/fuel/app/migrations/051_add_action_to_notifications.php
+++ b/fuel/app/migrations/051_add_action_to_notifications.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Fuel\Migrations;
+
+class Add_action_to_notifications
+{
+	public function up()
+	{
+		\DBUtil::add_fields('notification', array(
+			'action' => ['constraint' => 255, 'type' => 'varchar', 'null' => false]
+		));
+	}
+
+	public function down()
+	{
+		\DBUtil::drop_fields('notification', ['action']);
+	}
+}

--- a/fuel/app/modules/lti/classes/controller/lti.php
+++ b/fuel/app/modules/lti/classes/controller/lti.php
@@ -134,6 +134,7 @@ class Controller_Lti extends \Controller
 		$this->insert_analytics();
 
 		\Js::push_inline('var BASE_URL = "'.\Uri::base().'";');
+		\Js::push_inline('var inst_id = "'.$inst_id.'";');
 		\Js::push_inline('var STATIC_CROSSDOMAIN = "'.\Config::get('materia.urls.static').'";');
 
 		\Css::push_group(['core', 'lti']);

--- a/fuel/app/modules/lti/classes/controller/lti.php
+++ b/fuel/app/modules/lti/classes/controller/lti.php
@@ -114,6 +114,10 @@ class Controller_Lti extends \Controller
 	{
 		$inst = \Materia\Widget_Instance_Manager::get($inst_id);
 
+		// If the current user does not have ownership over the embedded widget, find all of the users who do
+		$current_user_owns = \Materia\Perm_Manager::user_has_any_perm_to(\Model_User::find_current_id(), $inst_id, \Materia\Perm::INSTANCE, [\Materia\Perm::FULL]);
+		$instance_owner_list = $current_user_owns ? [] : $inst->get_owners();
+
 		$this->theme->set_template('layouts/main')
 			->set('title', 'Widget Connected Successfully')
 			->set('page_type', 'preview');
@@ -123,7 +127,9 @@ class Controller_Lti extends \Controller
 			->set('widget_name', $inst->widget->name)
 			->set('preview_url', \Uri::create('/preview/'.$inst_id))
 			->set('icon', \Config::get('materia.urls.engines')."{$inst->widget->dir}img/icon-92.png")
-			->set('preview_embed_url', \Uri::create('/preview-embed/'.$inst_id));
+			->set('preview_embed_url', \Uri::create('/preview-embed/'.$inst_id))
+			->set('current_user_owns', $current_user_owns)
+			->set('instance_owner_list', $instance_owner_list);
 
 		$this->insert_analytics();
 

--- a/fuel/app/themes/default/lti/layouts/test_provider.php
+++ b/fuel/app/themes/default/lti/layouts/test_provider.php
@@ -213,7 +213,7 @@
 				One of the advantages of this method is the signature is generated and timestamped
 				when you click the button.  The other buttons on this page build the signature and timestamp
 				when the page is loaded - so they can easily expire
-			 -->
+			-->
 
 			<form onsubmit="setLtiUrl(this)" method="POST" target="embed_iframe" action="<?= $learner_endpoint ?>" >
 				<input type="hidden" class="lti_url" name="lti_url" />
@@ -268,6 +268,15 @@
 				<input type="submit" id="play_as_instructor" value="As Instructor">
 			</form>
 
+			<form onsubmit="setLtiUrl(this)" method="POST" target="embed_iframe" action="<?= $learner_endpoint ?>" >
+				<input type="hidden" class="lti_url" name="lti_url" />
+				<input type="hidden" class="context_id" name="context_id" />
+				<input type="hidden" class="resource_link" name="resource_link" />
+				<input type="hidden" class="custom_widget_instance_id" name="custom_widget_instance_id" />
+				<input type="hidden" id="as_instructor2" name="as_instructor2" value="as_instructor2" />
+				<input type="submit" id="play_as_instructor2" value="As New Instructor">
+			</form>
+
 			<hr />
 			<h2>Other</h2>
 
@@ -284,7 +293,7 @@
 					<? if($name == 'oauth_signature') : ?>
 						<?= \Form::hidden('oauth_signature', 'THIS_WILL_FAIL') ?>
 					<? else: ?>
-					 	<?= \Form::hidden($name, $value) ?>
+						<?= \Form::hidden($name, $value) ?>
 					<? endif ?>
 				<?php endforeach ?>
 				<input type="submit" value="Test Validation (bad signature)">

--- a/fuel/app/themes/default/lti/partials/open_preview.php
+++ b/fuel/app/themes/default/lti/partials/open_preview.php
@@ -4,35 +4,51 @@
 </header>
 <section>
 	<?php if(!$current_user_owns): ?>
+		<script type="text/javascript">
+			const requestAccess = (owner_id) => {
+				let req = new XMLHttpRequest()
+				req.open('POST', '/api/instance/request_access')
+				req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded')
+				req.send(`inst_id=${inst_id}&owner_id=${owner_id}`)
+			}
+		</script>
 		<div class="help-container">
+			<div class="widget_info">
+				<div class="widget_icon">
+					<img src="<?= $icon ?>" alt="<?= $widget_name ?> Type Widget Icon">
+				</div>
+				<div class="widget_name"><?= $inst_name ?></div>
+			</div>
 			<p>You don't own this widget!</p>
 			<p>Please contact one of the widget owners listed below to request access to this widget:</p>
 			<ul>
 				<?php foreach($instance_owner_list as $owner):?>
 					<li>
-						<a href=<?= 'mailto:'.$owner->email ?>>
-							<?= $owner->first.' '.$owner->last ?>
-							(<?= $owner->email ?>)
-						</a>
+						<?= $owner->first.' '.$owner->last ?>
+						<button id="request_widget_access" onclick="requestAccess(<?= $owner->id ?>)">Request Access</button>
 					</li>
 				<?php endforeach; ?>
 			</ul>
-		</div>
-	<?php endif; ?>
 
-	<div class="container">
-		<div class="widget_info">
-			<div class="widget_icon">
-				<img src="<?= $icon ?>" alt="<?= $widget_name ?> Type Widget Icon">
+			<p>You may also request access to the widget by clicking the option below. The owner will receive a notification with the option to grant you access.</p>
+		</div>
+	<?php else: ?>
+
+		<div class="container">
+			<div class="widget_info">
+				<div class="widget_icon">
+					<img src="<?= $icon ?>" alt="<?= $widget_name ?> Type Widget Icon">
+				</div>
+				<div class="widget_name"><?= $inst_name ?></div>
 			</div>
-			<div class="widget_name"><?= $inst_name ?></div>
+			<p>Students will see the widget instead of this message. When supported, Materia will synchronize scores.</p>
+			<a class="button" href="<?= $preview_embed_url ?>">Start Preview</a>
 		</div>
-		<p>Students will see the widget instead of this message. When supported, Materia will synchronize scores.</p>
-		<a class="button" href="<?= $preview_embed_url ?>">Start Preview</a>
-	</div>
 
-	<div class="help-container">
-		<p class="note">Preview restricted by widget permissions in Materia.</p>
-		<p>To view the widget in Canvas as a student, view the assignment while in <a href="https://webcourses.ucf.edu/profile/settings" target="_blank" class="external">Student View</a>.</p>
-	</div>
+		<div class="help-container">
+			<p class="note">Preview restricted by widget permissions in Materia.</p>
+			<p>To view the widget in Canvas as a student, view the assignment while in <a href="https://webcourses.ucf.edu/profile/settings" target="_blank" class="external">Student View</a>.</p>
+		</div>
+
+	<?php endif; ?>
 </section>

--- a/fuel/app/themes/default/lti/partials/open_preview.php
+++ b/fuel/app/themes/default/lti/partials/open_preview.php
@@ -3,6 +3,23 @@
 	<div id="logo"></div>
 </header>
 <section>
+	<?php if(!$current_user_owns): ?>
+		<div class="help-container">
+			<p>You don't own this widget!</p>
+			<p>Please contact one of the widget owners listed below to request access to this widget:</p>
+			<ul>
+				<?php foreach($instance_owner_list as $owner):?>
+					<li>
+						<a href=<?= 'mailto:'.$owner->email ?>>
+							<?= $owner->first.' '.$owner->last ?>
+							(<?= $owner->email ?>)
+						</a>
+					</li>
+				<?php endforeach; ?>
+			</ul>
+		</div>
+	<?php endif; ?>
+
 	<div class="container">
 		<div class="widget_info">
 			<div class="widget_icon">

--- a/fuel/app/themes/default/lti/partials/open_preview.php
+++ b/fuel/app/themes/default/lti/partials/open_preview.php
@@ -5,32 +5,42 @@
 <section>
 	<?php if(!$current_user_owns): ?>
 		<script type="text/javascript">
+
+			const requested = []
+
 			const requestAccess = (owner_id) => {
+
+				if (requested[owner_id]) return
+
 				let req = new XMLHttpRequest()
 				req.open('POST', '/api/instance/request_access')
 				req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded')
 				req.send(`inst_id=${inst_id}&owner_id=${owner_id}`)
+				
+				let el = document.getElementById(`owner-${owner_id}`)
+				el.setAttribute('disabled', 'disabled')
+				el.className = 'button disabled'
+
+				requested[owner_id] = true
 			}
 		</script>
-		<div class="help-container">
+		<div class="container not_an_owner">
 			<div class="widget_info">
 				<div class="widget_icon">
 					<img src="<?= $icon ?>" alt="<?= $widget_name ?> Type Widget Icon">
 				</div>
 				<div class="widget_name"><?= $inst_name ?></div>
 			</div>
-			<p>You don't own this widget!</p>
-			<p>Please contact one of the widget owners listed below to request access to this widget:</p>
+			<h3>You don't own this widget!</h3>
+			<p>You may contact one of the widget owners listed below to request access to this widget. Clicking the Request Access option will notify them and provide them the option to add you as a collaborator.</p>
 			<ul>
 				<?php foreach($instance_owner_list as $owner):?>
-					<li>
+					<li class="instance_owner">
 						<?= $owner->first.' '.$owner->last ?>
-						<button id="request_widget_access" onclick="requestAccess(<?= $owner->id ?>)">Request Access</button>
+						<a id="owner-<?= $owner->id ?>" class="button request_widget_access" onclick="requestAccess(<?= $owner->id ?>)">Request Access</a>
 					</li>
 				<?php endforeach; ?>
 			</ul>
-
-			<p>You may also request access to the widget by clicking the option below. The owner will receive a notification with the option to grant you access.</p>
 		</div>
 	<?php else: ?>
 

--- a/fuel/app/themes/default/partials/header.php
+++ b/fuel/app/themes/default/partials/header.php
@@ -72,6 +72,7 @@
 				<p class="icon"><img class="senderAvatar" ng-src="{{notification.avatar}}"></p>
 				<div class="notice_right_side">
 					<p class="subject" ng-bind-html="trust(notification.subject)"></p>
+					<button class="notification_action" ng-if="notification.action" ng-click="notification.button_action_callback()">{{notification.button_action_text}}</button>
 				</div>
 				<span class="noticeClose" ng-click="removeNotification($index, notification.id)"></span>
 			</div>

--- a/fuel/app/themes/default/partials/header.php
+++ b/fuel/app/themes/default/partials/header.php
@@ -72,7 +72,7 @@
 				<p class="icon"><img class="senderAvatar" ng-src="{{notification.avatar}}"></p>
 				<div class="notice_right_side">
 					<p class="subject" ng-bind-html="trust(notification.subject)"></p>
-					<button class="notification_action" ng-if="notification.action" ng-click="notification.button_action_callback()">{{notification.button_action_text}}</button>
+					<button class="action_button notification_action" ng-if="notification.action" ng-click="notification.button_action_callback()">{{notification.button_action_text}}</button>
 				</div>
 				<span class="noticeClose" ng-click="removeNotification($index, notification.id)"></span>
 			</div>

--- a/fuel/app/themes/default/partials/my_widgets.php
+++ b/fuel/app/themes/default/partials/my_widgets.php
@@ -120,6 +120,7 @@
 							<div ng-repeat="collaborator in perms.collaborators"
 								ng-show="!collaborator.remove || collaborator.warning"
 								class="user_perm"
+								ng-class="{'highlight' : collaborator.highlight}"
 								data-user-id="{{collaborator.id}}">
 								<a ng-if="selected.shareable || user.id == collaborator.id"
 									tabindex="0"

--- a/fuel/app/themes/default/partials/my_widgets.php
+++ b/fuel/app/themes/default/partials/my_widgets.php
@@ -65,6 +65,7 @@
 				dialog-title="Collaborate"
 				width="620px"
 				height="500px"
+				on-close="handleDialogClose()"
 			>
 				<div
 					ng-if="show.collaborationModal"
@@ -194,7 +195,7 @@
 						</p>
 						<a tabindex="0"
 							class="cancel_button"
-							ng-click="handleCollabCancel()">
+							ng-click="hideModal()">
 							Cancel
 						</a>
 						<a tabindex="0"

--- a/fuel/app/themes/default/partials/my_widgets.php
+++ b/fuel/app/themes/default/partials/my_widgets.php
@@ -194,7 +194,7 @@
 						</p>
 						<a tabindex="0"
 							class="cancel_button"
-							ng-click="hideModal()">
+							ng-click="handleCollabCancel()">
 							Cancel
 						</a>
 						<a tabindex="0"


### PR DESCRIPTION
Branched off #1341 

Adds a new option to the LTI embed preview screen that's circumstantially enabled if a user is not an owner of the widget. It allows a user to request access to the embedded widget. The selected owner will be given a notification with an option to grant ownership to the person who made the request.

To be paired with https://github.com/ucfopen/Materia-Server-Client-Assets/pull/125

**This pull request includes a migration**