### PR TITLE
slightly bumps mysql version to one that can be emulated on m1 arch

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -57,7 +57,8 @@ services:
       - fakes3
 
   mysql:
-    image: mysql:5.7.18
+    image: mysql:5.7.34
+    platform: linux/amd64
     ports:
       - "3306:3306" # allow mysql access from the host - use /etc/hosts to set mysql to your docker-machine ip
     networks:


### PR DESCRIPTION
`platform: linux/amd64` runs an intel image under emulation on ARM architecture, runs normally on intel architecture. 

Tested on 
- [x] M1 MacBook Pro
- [x] MacBook Pro 2017
