### PR TITLE
Alpha tags trigger a pre-release instead of a full release

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -53,6 +53,7 @@ jobs:
           cd docker && ./run_build_github_release_package.sh ghcr.io/${{ github.repository_owner }}/materia:app-${{ steps.tag_name.outputs.GIT_TAG }}
 
       - name: Upload to Release
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-alpha') }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -60,3 +61,14 @@ jobs:
           file_glob: true
           tag: ${{ github.ref }}
           overwrite: true
+
+      - name: Upload to Pre-Release
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-alpha') }}
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: materia-pkg*
+          file_glob: true
+          tag: ${{ github.ref }}
+          overwrite: true
+          prerelease: true


### PR DESCRIPTION
Tested on my own fork and it appears to do the job.