### PR TITLE
Security hardening and enhancements

### DIFF
--- a/docker/config/nginx/nginx-dev.conf
+++ b/docker/config/nginx/nginx-dev.conf
@@ -70,6 +70,9 @@ http {
         listen *:443 ssl;
         listen [::]:443 ssl;
 
+        # Set HSTS header with a duration of 12 hours
+        add_header Strict-Transport-Security "max-age=43200; includeSubDomains" always;
+
         error_page 404 = @handler;
         error_page 405 = @handler;
 
@@ -151,6 +154,9 @@ http {
     server{
         listen *:8008 ssl;
         listen [::]:8008 ssl;
+
+        # Set HSTS header with a duration of 12 hours
+        add_header Strict-Transport-Security "max-age=43200; includeSubDomains" always;
 
         # @TODO: match only /js/* /css/* and /widget/*
         location ~* ^.+\.(html|ogv|svg|svgz|eot|otf|woff|mp4|ttf|rss|atom|jpg|jpeg|gif|png|ico|zip|tgz|gz|rar|bz2|doc|xls|exe|ppt|tar|mid|midi|wav|bmp|rtf|js|css|json|obj)$ {

--- a/docker/config/nginx/nginx-production.conf
+++ b/docker/config/nginx/nginx-production.conf
@@ -54,6 +54,9 @@ http {
         listen [::]:80;
         server_name default_server;
 
+        # Set HSTS header with a duration of 12 hours
+        add_header Strict-Transport-Security "max-age=43200; includeSubDomains" always;
+
         # Forward ip addresses from the load balancer
         set_real_ip_from 10.0.0.0/8;
         real_ip_header X-Forwarded-For;

--- a/fuel/app/themes/default/partials/widget/guide_doc.php
+++ b/fuel/app/themes/default/partials/widget/guide_doc.php
@@ -2,12 +2,12 @@
 	<div id="top">
 		<h1><?= $name ?></h1>
 		<div id="guide-tabs" class="<?= $type ?>-guide">
-			<? if ($has_player_guide): ?>
+			<?php if ($has_player_guide): ?>
 			<a href="./players-guide">Player Guide</a>
-			<? endif; ?>
-			<? if ($has_creator_guide): ?>
+			<?php endif; ?>
+			<?php if ($has_creator_guide): ?>
 			<a href="./creators-guide">Creator Guide</a>
-			<? endif; ?>
+			<?php endif; ?>
 		</div>
 	</div>
 	<div id="guide-container">


### PR DESCRIPTION
- Fixes inline php tags to prevent server-side code from being rendered client-side.
- Adds HSTS headers to nginx-dev and nginx-prod.

The `X-Frame-Options` header appears to be a non-starter, as `ALLOW-FROM` does not yet have broad browser support and `SAMEORIGIN` disallows requests from the non-static domain.