### PR TITLE
Dev/9.0.1 typhoon hotfixes

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -53,6 +53,7 @@ jobs:
           cd docker && ./run_build_github_release_package.sh ghcr.io/${{ github.repository_owner }}/materia:app-${{ steps.tag_name.outputs.GIT_TAG }}
 
       - name: Upload to Release
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-alpha') }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -60,3 +61,14 @@ jobs:
           file_glob: true
           tag: ${{ github.ref }}
           overwrite: true
+
+      - name: Upload to Pre-Release
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-alpha') }}
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: materia-pkg*
+          file_glob: true
+          tag: ${{ github.ref }}
+          overwrite: true
+          prerelease: true

--- a/docker/config/nginx/nginx-dev.conf
+++ b/docker/config/nginx/nginx-dev.conf
@@ -11,7 +11,7 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    log_format slim '[$time_local] "$request_method $request_uri" $status';
+    log_format slim '[$time_local] "$request_method $request_uri" $status - $remote_addr';
 
     access_log  /var/log/nginx/access.log  main;
 

--- a/docker/config/nginx/nginx-production.conf
+++ b/docker/config/nginx/nginx-production.conf
@@ -11,7 +11,7 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    log_format slim '[$time_local] "$request_method $request_uri" $status';
+    log_format slim '[$time_local] "$request_method $request_uri" $status - $remote_addr';
 
     access_log  /var/log/nginx/access.log  main;
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -57,7 +57,8 @@ services:
       - fakes3
 
   mysql:
-    image: mysql:5.7.18
+    image: mysql:5.7.34
+    platform: linux/amd64
     ports:
       - "3306:3306" # allow mysql access from the host - use /etc/hosts to set mysql to your docker-machine ip
     networks:

--- a/fuel/app/classes/materia/api/v1.php
+++ b/fuel/app/classes/materia/api/v1.php
@@ -71,7 +71,7 @@ class Api_V1
 	static public function widget_instance_access_perms_verify($inst_id)
 	{
 		if (\Service_User::verify_session() !== true) return Msg::no_login();
-		return static::has_perms_to_inst($inst_id, [Perm::SCORE, Perm::FULL]);
+		return static::has_perms_to_inst($inst_id, [Perm::VISIBLE, Perm::FULL]);
 	}
 
 	/**

--- a/fuel/app/config/config.php
+++ b/fuel/app/config/config.php
@@ -333,8 +333,8 @@ return array(
 		],
 		[
 			'id' => 2,
-			'package'  => 'https://github.com/ucfopen/hangman-materia-widget/releases/latest/download/hangman.wigt',
-			'checksum' => 'https://github.com/ucfopen/hangman-materia-widget/releases/latest/download/hangman-build-info.yml',
+			'package'  => 'https://github.com/ucfopen/guess-the-phrase-materia-widget/releases/latest/download/guess-the-phrase.wigt',
+			'checksum' => 'https://github.com/ucfopen/guess-the-phrase-materia-widget/releases/latest/download/guess-the-phrase-build-info.yml',
 		],
 		[
 			'id' => 3,

--- a/fuel/app/modules/lti/classes/controller/lti.php
+++ b/fuel/app/modules/lti/classes/controller/lti.php
@@ -115,7 +115,7 @@ class Controller_Lti extends \Controller
 		$inst = \Materia\Widget_Instance_Manager::get($inst_id);
 
 		// If the current user does not have ownership over the embedded widget, find all of the users who do
-		$current_user_owns = \Materia\Perm_Manager::user_has_any_perm_to(\Model_User::find_current_id(), $inst_id, \Materia\Perm::INSTANCE, [\Materia\Perm::FULL]);
+		$current_user_owns = \Materia\Perm_Manager::user_has_any_perm_to(\Model_User::find_current_id(), $inst_id, \Materia\Perm::INSTANCE, [\Materia\Perm::VISIBLE, \Materia\Perm::FULL]);
 		$instance_owner_list = $current_user_owns ? [] : $inst->get_owners();
 
 		$this->theme->set_template('layouts/main')

--- a/package.json
+++ b/package.json
@@ -41,5 +41,5 @@
     "hammerjs": "hammerjs/hammer.js#v2.0.8",
     "spinjs": "https://github.com/fgnass/spin.js.git#1.2.8"
   },
-  "version": "9.0.0-alpha3"
+  "version": "9.0.1-alpha1"
 }

--- a/package.json
+++ b/package.json
@@ -41,5 +41,5 @@
     "hammerjs": "hammerjs/hammer.js#v2.0.8",
     "spinjs": "https://github.com/fgnass/spin.js.git#1.2.8"
   },
-  "version": "9.0.1-alpha1"
+  "version": "9.0.1-alpha2"
 }


### PR DESCRIPTION
- Update references to the widget previously known as Hangman to Guess the Phrase.
- Added some basic CSRF mitigation to v1 API calls.
- The `build_and_release` GitHub action will mark alpha tags as pre-release.
- nginx configurations will now include `remote_addr` in logs by default.
- Bumped the version of mysql slightly to allow support for M1 machines.
- Adjusted permission checks to correct visibility issues for widgets for which a user has read-only access.