### PR TITLE
Fixes show_engines task

### DIFF
--- a/fuel/app/tasks/widget.php
+++ b/fuel/app/tasks/widget.php
@@ -85,7 +85,7 @@ class Widget extends \Basetask
 		foreach ($engines as $engine)
 		{
 			\Cli::write(
-				\Cli::color(str_pad($engine['id'], 3, ' ', STR_PAD_LEFT).' : ', 'green').\Cli::color($engine['name'], 'yellow').\Cli::color(' '.$engine['group'], 'red')
+				\Cli::color(str_pad($engine['id'], 3, ' ', STR_PAD_LEFT).' : ', 'green').\Cli::color($engine['name'], 'yellow')
 			);
 		}
 	}


### PR DESCRIPTION
show_engines was erroring because it was attempting to look up a property that was removed from the widget table years ago.

Fixes #1393 