### PR TITLE
Replaced broken heroku slack invite link with dl.ucf.edu slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 View the [Materia Docs](http://ucfopen.github.io/Materia-Docs/) for info on installing, using, and developing Materia and widgets.
 
-[Join UCF Open Slack Discussions](https://ucf-open-slackin.herokuapp.com/) [![Join UCF Open Slack Discussions](https://ucf-open-slackin.herokuapp.com/badge.svg)](https://ucf-open-slackin.herokuapp.com/)
+[Join UCF Open Slack Discussions](https://dl.ucf.edu/join-ucfopen/) [![Join UCF Open Slack Discussions](https://badgen.net/badge/icon/ucfopen?icon=slack&label=slack&color=e01563)](https://dl.ucf.edu/join-ucfopen/)
 
 ## Quick Heroku Deploy
 


### PR DESCRIPTION
Updated broken links and replaced old badge with [badgen.net](https://badgen.net/) badge using the same branding colors.