### PR TITLE
Issue/1411 user admin instance management

### DIFF
--- a/src/components/hooks/useCopyWidget.jsx
+++ b/src/components/hooks/useCopyWidget.jsx
@@ -33,12 +33,10 @@ export default function useCopyWidget() {
 
 				// 'setQueryData()' is a sync method
 				queryClient.setQueryData('widgets', updateData) // can confirm 'widgets' is updating
-				console.log(updateData)
 				return { previousValue }
 			},
 			onSuccess: (data, variables) => {
 				queryClient.invalidateQueries('widgets')
-				variables.successFunc(data)
 			},
 			onError: (err, newWidget, context) => {
 				queryClient.setQueryData('widgets', context.previousValue)

--- a/src/components/hooks/useCopyWidget.jsx
+++ b/src/components/hooks/useCopyWidget.jsx
@@ -33,11 +33,12 @@ export default function useCopyWidget() {
 
 				// 'setQueryData()' is a sync method
 				queryClient.setQueryData('widgets', updateData) // can confirm 'widgets' is updating
-
+				console.log(updateData)
 				return { previousValue }
 			},
-			onSuccess: () => {
+			onSuccess: (data, variables) => {
 				queryClient.invalidateQueries('widgets')
+				variables.successFunc(data)
 			},
 			onError: (err, newWidget, context) => {
 				queryClient.setQueryData('widgets', context.previousValue)

--- a/src/components/hooks/useSupportDeleteWidget.jsx
+++ b/src/components/hooks/useSupportDeleteWidget.jsx
@@ -10,9 +10,7 @@ export default function useSupportDeleteWidget() {
 			onSuccess: (data, variables) => {
 				if (data !== null) {
 					variables.successFunc()
-					queryClient.removeQueries('search-widgets', {
-						exact: false
-					})
+					queryClient.invalidateQueries('widgets')
 				}
 				else {
 					console.log('failed to delete widget')

--- a/src/components/hooks/useSupportUpdateWidget.jsx
+++ b/src/components/hooks/useSupportUpdateWidget.jsx
@@ -10,11 +10,19 @@ export default function useSupportUpdateWidget() {
 		{
 			onSuccess: (data, variables) => {
 				variables.successFunc()
+
+				// Refresh widgets
+				queryClient.invalidateQueries('widgets')
+
 				queryClient.removeQueries('search-widgets', {
 					exact: false
 				})
 			},
-			onError: (err, newWidget, context) => variables.errorFunc()
+			onError: (err, newWidget, context) => {
+				queryClient.setQueryData('widgets', context.previousValue)
+				
+				variables.errorFunc()
+			}
 		}
 	)
 }

--- a/src/components/hooks/useUpdateWidget.jsx
+++ b/src/components/hooks/useUpdateWidget.jsx
@@ -11,26 +11,26 @@ export default function useUpdateWidget() {
 			onMutate: async inst => {
 				await queryClient.cancelQueries('widgets')
 
-				const copyValue = [...queryClient.getQueryData('widgets')]
-				const previousValue = queryClient.getQueryData('widgets')
+				const previousWidgets = queryClient.getQueryData('widgets')
 
-				for (const val of copyValue) {
-					if (val.id === inst.args[0]) {
-						val.open_at = `${inst.args[4]}`
-						val.close_at = `${inst.args[5]}`
-						val.attempts = `${inst.args[6]}`
-						val.guest_access = inst.args[7]
-						val.embedded_only = inst.args[8]
+				if (previousWidgets) {
+					for (const val of previousWidgets.pagination) {
+						if (val.id === inst.args[0]) {
+							val.open_at = `${inst.args[4]}`
+							val.close_at = `${inst.args[5]}`
+							val.attempts = `${inst.args[6]}`
+							val.guest_access = inst.args[7]
+							val.embedded_only = inst.args[8]
+						}
 					}
+					queryClient.setQueryData('widgets', previousWidgets)
 				}
-
-				queryClient.setQueryData('widgets', () => copyValue)
-
+				
 				// Stores the old value for use if there is an error
-				return { previousValue }
+				return { previousWidgets }
 			},
-			onSuccess: (data, variables) => {
-				variables.successFunc()
+			onSuccess: (updatedInst, variables) => {
+				variables.successFunc(updatedInst)
 				queryClient.invalidateQueries('widgets')
 				queryClient.invalidateQueries(['user-perms', variables.args[0]])
 			},

--- a/src/components/my-widgets-page.jsx
+++ b/src/components/my-widgets-page.jsx
@@ -57,10 +57,13 @@ const MyWidgetsPage = () => {
 			keepPreviousData: true,
 			refetchOnWindowFocus: false,
 			onSuccess: (data) => {
+				// Removes duplicates
+				let widgetSet = new Set([...data.pagination, ...state.widgetList])
+
 				setState({
 					...state,
 					totalPages: data.total_num_pages,
-					widgetList: [...state.widgetList, ...data.pagination].sort(_compareWidgets)
+					widgetList: [...widgetSet].sort(_compareWidgets)
 				})
 			},
 		})
@@ -129,7 +132,7 @@ const MyWidgetsPage = () => {
 
 				setState({
 					...state,
-					selectedInst: selectWidget && widgetFound ? widgetFound : null,
+					selectedInst: widgetFound,
 					loadingWidgets: false,
 					noAccess: widgetFound == null,
 				})
@@ -183,7 +186,8 @@ const MyWidgetsPage = () => {
 				title: newTitle,
 				copyPermissions: newPerm,
 				widgetName: inst.widget.name,
-				dir: inst.widget.dir
+				dir: inst.widget.dir,
+				successFunc: () => {}
 			},
 			{
 				// Still waiting on the widget list to refresh, return to a 'loading' state and indicate a post-fetch change is coming.
@@ -228,6 +232,17 @@ const MyWidgetsPage = () => {
 				}
 			}
 		)
+	}
+
+	const onEdit = (inst) => {
+		setState({
+			...state,
+			selectedInst: inst,
+			widgetHash: inst.id,
+			page: 1,
+			widgetList: [],
+			forcedRefresh: true
+		})
 	}
 
 	/**
@@ -313,6 +328,7 @@ const MyWidgetsPage = () => {
 				inst={state.selectedInst}
 				onDelete={onDelete}
 				onCopy={onCopy}
+				onEdit={onEdit}
 				currentUser={user}
 				myPerms={state.myPerms}
 				otherUserPerms={state.otherUserPerms}

--- a/src/components/my-widgets-settings-dialog.jsx
+++ b/src/components/my-widgets-settings-dialog.jsx
@@ -74,7 +74,7 @@ const attemptsToIndex = (attempts) => {
 	}
 }
 
-const MyWidgetsSettingsDialog = ({ onClose, inst, currentUser, otherUserPerms }) => {
+const MyWidgetsSettingsDialog = ({ onClose, inst, currentUser, otherUserPerms, onEdit }) => {
 	const [state, setState] = useState(initState())
 	const mounted = useRef(false)
 	const mutateWidget = useUpdateWidget()
@@ -250,7 +250,9 @@ const MyWidgetsSettingsDialog = ({ onClose, inst, currentUser, otherUserPerms })
 
 			mutateWidget.mutate({
 				args: args,
-				successFunc: () => {
+				successFunc: (updatedInst) => {
+					console.log(updatedInst)
+					onEdit(updatedInst)
 					if (mounted.current) {
 						onClose()
 					}

--- a/src/components/support-page.scss
+++ b/src/components/support-page.scss
@@ -265,8 +265,13 @@ h1 {
 					}
 
 					.error-text {
-						height: 15px;
 						color: red;
+						font-size: 0.8em;
+						text-align: center;
+					}
+
+					.success-text {
+						color: green;
 						font-size: 0.8em;
 						text-align: center;
 					}

--- a/src/components/support-selected-instance.jsx
+++ b/src/components/support-selected-instance.jsx
@@ -33,7 +33,7 @@ const stringToDateObj = (date, time) => Date.parse(date + 'T' + time) / 1000
 
 const stringToBoolean = s => s === 'true'
 
-const SupportSelectedInstance = ({inst, currentUser, onReturn, onCopy}) => {
+const SupportSelectedInstance = ({inst, currentUser, onReturn = null, onCopy, embed = false}) => {
 	const [updatedInst, setUpdatedInst] = useState({...inst})
 	const [showCopy, setShowCopy] = useState(false)
 	const [showCollab, setShowCollab] = useState(false)
@@ -45,6 +45,7 @@ const SupportSelectedInstance = ({inst, currentUser, onReturn, onCopy}) => {
 	const [closeDate, setCloseDate] = useState(inst.close_at < 0 ? '' : objToDateString(inst.close_at))
 	const [closeTime, setCloseTime] = useState(inst.close_at < 0 ? '' : objToTimeString(inst.close_at))
 	const [errorText, setErrorText] = useState('')
+	const [successText, setSuccessText] = useState('')
 	const [allPerms, setAllPerms] = useState({myPerms: null, otherUserPerms: null})
 	const deleteWidget = useDeleteWidget()
 	const unDeleteWidget = useUnDeleteWidget()
@@ -110,6 +111,9 @@ const SupportSelectedInstance = ({inst, currentUser, onReturn, onCopy}) => {
 			else {
 				u.open_at = stringToDateObj(availableDate, availableTime)
 			}
+			setUpdatedInst({...updatedInst,
+				'open_at': stringToDateObj(availableDate, availableTime)
+			})
 		}
 		if (!closeDisabled){
 			if(closeDate == '' || closeTime == '') {
@@ -119,6 +123,9 @@ const SupportSelectedInstance = ({inst, currentUser, onReturn, onCopy}) => {
 			else {
 				u.close_at = stringToDateObj(closeDate, closeTime)
 			}
+			setUpdatedInst({...updatedInst,
+				'close_at': stringToDateObj(closeDate, closeTime)
+			})
 		}
 
 		//make sure title is not blank
@@ -127,10 +134,6 @@ const SupportSelectedInstance = ({inst, currentUser, onReturn, onCopy}) => {
 			return
 		}
 
-		setUpdatedInst({...updatedInst,
-			'open_at': stringToDateObj(availableDate, availableTime),
-			'close_at': stringToDateObj(closeDate, closeTime)
-		})
 
 		const args = [
 			u.id,
@@ -146,8 +149,14 @@ const SupportSelectedInstance = ({inst, currentUser, onReturn, onCopy}) => {
 
 		updateWidget.mutate({
 			args: args,
-			successFunc: () => setErrorText('Success!'),
-			errorFunc: () => setErrorText('Error: Update Unsuccessful')
+			successFunc: () => {
+				setSuccessText('Success!')
+				setErrorText('')
+			},
+			errorFunc: () => {
+				setErrorText('Error: Update Unsuccessful')
+				setSuccessText('')
+			}
 		})
 	}
 
@@ -184,8 +193,9 @@ const SupportSelectedInstance = ({inst, currentUser, onReturn, onCopy}) => {
 		)
 	}
 
-	return (
-		<section className='page inst-info'>
+	let breadcrumbContainer = null
+	if (!embed) {
+		breadcrumbContainer =
 			<div id="breadcrumb-container">
 				<div className="breadcrumb">
 					<a href="/admin/instance">Instance Search</a>
@@ -199,6 +209,11 @@ const SupportSelectedInstance = ({inst, currentUser, onReturn, onCopy}) => {
 				</svg>
 				<div className="breadcrumb">{updatedInst.name}</div>
 			</div>
+	}
+
+	return (
+		<section className='page inst-info'>
+			{ breadcrumbContainer }
 			<div className='instance-management'>
 				<div className='header'>
 				<img src={iconUrl('/widget/', updatedInst.widget.dir, 60)} />
@@ -382,6 +397,7 @@ const SupportSelectedInstance = ({inst, currentUser, onReturn, onCopy}) => {
 							<span>Apply Changes</span>
 						</button>
 						<span className='error-text'>{errorText}</span>
+						<span className='success-text'>{successText}</span>
 					</div>
 				</div>
 

--- a/src/components/user-admin-instance-available.jsx
+++ b/src/components/user-admin-instance-available.jsx
@@ -1,13 +1,46 @@
 import React, { useState } from 'react'
 import { iconUrl } from '../util/icon-url'
+import SupportSelectedInstance from './support-selected-instance'
+import useCopyWidget from './hooks/useCopyWidget'
 
-const UserAdminInstanceAvailable = ({instance, index}) => {
+const UserAdminInstanceAvailable = ({instance, index, currentUser}) => {
 
-	const [instanceState, setInstanceState] = useState({expanded: false})
+	const copyWidget = useCopyWidget()
+
+	const [instanceState, setInstanceState] = useState({
+		expanded: false,
+		manager: false
+	})
+
+	const onCopy = (instId, title, copyPerms, inst) => {
+		copyWidget.mutate({
+			instId: instId,
+			title: title,
+			copyPermissions: copyPerms,
+			dir: inst.widget.dir,
+			successFunc: (copyId) => {
+				if (!copyPerms) {
+					window.location = `/my-widgets#${copyId}`
+				}
+			}
+		})
+	}
+
+	let managerRender = null
+	if (instanceState.manager) {
+		managerRender = (
+			<SupportSelectedInstance inst={instance}
+				key={instance ? instance.id : ''}
+				currentUser={currentUser} onCopy={onCopy}
+				embed={true}
+			/>
+		)
+	}
 
 	return (
-		<li key={index} className={`instance ${instanceState.expanded ? 'expanded' : ''}`} onClick={() => setInstanceState(instanceState => ({...instanceState, expanded: !instanceState.expanded}))}>
-			<div className='clickable widget-title'>
+		<li key={index} className={`instance ${instanceState.expanded ? 'expanded' : ''}`}>
+			<div className={`clickable widget-title ${instanceState.manager ? 'hidden' : ''}`} 
+		onClick={() => setInstanceState(instanceState => ({...instanceState, expanded: !instanceState.expanded, manager: false}))}>
 				<span className='img-holder'>
 					<img src={iconUrl('/widget/', instance.widget.dir, 275)} />
 				</span>
@@ -20,78 +53,87 @@ const UserAdminInstanceAvailable = ({instance, index}) => {
 					</div>
 				</span>
 			</div>
-			<div className='info-holder'>
-				<div>
-					<span>
-						<label>ID:</label> { instance.id }
-					</span>
+			{ !instanceState.manager ? 
+				<div className={`info-holder`}>
+					<div>
+						<span>
+							<label>ID:</label> { instance.id }
+						</span>
+					</div>
+					<div>
+						<span>
+							<label>Created:</label> { `${new Date(instance.created_at * 1000).toLocaleDateString()} (${instance.created_at})` }
+						</span>
+					</div>
+					<div>
+						<span>
+							<label>Publish status:</label> { instance.is_draft ? 'Draft' : 'Published' }
+						</span>
+					</div>
+					<div>
+						<span>
+							<label>Student-Made:</label> { instance.is_student_made ? 'Yes' : 'No' }
+						</span>
+					</div>
+					<div>
+						<span>
+							<label>Access Type:</label> { instance.guest_access ? 'Guest Access' : 'Normal Access' }
+						</span>
+					</div>
+					<div>
+						<span>
+							<label>Student Collaborators: </label> { instance.student_access ? 'Yes' : 'No' }
+						</span>
+					</div>
+					<div>
+						<span>
+							<label>Embedded Only:</label> { instance.embedded_only ? 'Yes' : 'No' }
+						</span>
+					</div>
+					<div>
+						<span>
+							<label>Embedded:</label> { instance.is_embedded ? 'Yes' : 'No' }
+						</span>
+					</div>
+					<div>
+						<span>
+							<label>Open Time:</label> { instance.open_at < 0 ? 'Forever' : `${new Date(instance.open_at*1000).toLocaleString()} (${instance.open_at})` }
+						</span>
+					</div>
+					<div>
+						<span>
+							<label>Close Time:</label> { instance.close_at < 0 ? 'Never' : `${new Date(instance.close_at*1000).toLocaleString()} (${instance.close_at})` }
+						</span>
+					</div>
+					<div>
+						<span>
+							<label>Attempts Allowed:</label> { instance.attempts < 0 ? 'Unlimited' : instance.attempts }
+						</span>
+					</div>
+					<div>
+						<span>
+							<label>Play URL:</label><a target='_blank' href={ instance.play_url }>{ instance.play_url }</a>
+						</span>
+					</div>
+					<div>
+						<span>
+							<label>Preview URL:</label><a target='_blank' href={ instance.preview_url }>{ instance.preview_url }</a>
+						</span>
+					</div>
+					<div>
+						<span>
+							<label>Embed URL:</label><a target='_blank' href={ instance.embed_url }>{ instance.embed_url }</a>
+						</span>
+					</div>
+					<div className="manage-btn-container">
+						<button className="action_button" onClick={() => setInstanceState(instanceState => ({...instanceState, manager: true}))}>{instanceState.manager ? 'Close Manager' : 'Manage Instance'}</button>
+					</div>
 				</div>
-				<div>
-					<span>
-						<label>Created:</label> { `${new Date(instance.created_at * 1000).toLocaleDateString()} (${instance.created_at})` }
-					</span>
+			:
+				<div className="info-holder">
+					{ managerRender }
 				</div>
-				<div>
-					<span>
-						<label>Publish status:</label> { instance.is_draft ? 'Draft' : 'Published' }
-					</span>
-				</div>
-				<div>
-					<span>
-						<label>Student-Made:</label> { instance.is_student_made ? 'Yes' : 'No' }
-					</span>
-				</div>
-				<div>
-					<span>
-						<label>Access Type:</label> { instance.guest_access ? 'Guest Access' : 'Normal Access' }
-					</span>
-				</div>
-				<div>
-					<span>
-						<label>Student Collaborators: </label> { instance.student_access ? 'Yes' : 'No' }
-					</span>
-				</div>
-				<div>
-					<span>
-						<label>Embedded Only:</label> { instance.embedded_only ? 'Yes' : 'No' }
-					</span>
-				</div>
-				<div>
-					<span>
-						<label>Embedded:</label> { instance.is_embedded ? 'Yes' : 'No' }
-					</span>
-				</div>
-				<div>
-					<span>
-						<label>Open Time:</label> { instance.open_at < 0 ? 'Forever' : `${new Date(instance.open_at*1000).toLocaleString()} (${instance.open_at})` }
-					</span>
-				</div>
-				<div>
-					<span>
-						<label>Close Time:</label> { instance.close_at < 0 ? 'Never' : `${new Date(instance.close_at*1000).toLocaleString()} (${instance.close_at})` }
-					</span>
-				</div>
-				<div>
-					<span>
-						<label>Attempts Allowed:</label> { instance.attempts < 0 ? 'Unlimited' : instance.attempts }
-					</span>
-				</div>
-				<div>
-					<span>
-						<label>Play URL:</label><a target='_blank' href={ instance.play_url }>{ instance.play_url }</a>
-					</span>
-				</div>
-				<div>
-					<span>
-						<label>Preview URL:</label><a target='_blank' href={ instance.preview_url }>{ instance.preview_url }</a>
-					</span>
-				</div>
-				<div>
-					<span>
-						<label>Embed URL:</label><a target='_blank' href={ instance.embed_url }>{ instance.embed_url }</a>
-					</span>
-				</div>
-			</div>
+			}
 		</li>
 	)
 }

--- a/src/components/user-admin-page.jsx
+++ b/src/components/user-admin-page.jsx
@@ -15,7 +15,7 @@ const UserAdminPage = () => {
 	})
 
 	let pageRenderContent = <UserAdminSearch onClick={(user) => setSelectedUser(user)}/>
-	if (selectedUser) pageRenderContent = <UserAdminSelected user={selectedUser} currentUser={currentUser} onReturn={() => setSelectedUser(null)}></UserAdminSelected>
+	if (selectedUser) pageRenderContent = <UserAdminSelected selectedUser={selectedUser} currentUser={currentUser} onReturn={() => setSelectedUser(null)}></UserAdminSelected>
 
 	return (
 		<>

--- a/src/components/user-admin-page.scss
+++ b/src/components/user-admin-page.scss
@@ -204,7 +204,7 @@ h1 {
 
 			span {
 				display: block;
-				margin: 5px 0px;
+				// margin: 5px 0px;
 			}
 
 			label {
@@ -246,8 +246,13 @@ h1 {
 					}
 
 					.error-text {
-						height: 15px;
 						color: red;
+						font-size: 0.8em;
+						text-align: center;
+					}
+
+					.success-text {
+						color: green;
 						font-size: 0.8em;
 						text-align: center;
 					}
@@ -358,6 +363,11 @@ h1 {
 				border-bottom-right-radius: 0px;
 			}
 
+			.manage-btn-container {
+				display: flex;
+				justify-content: end;
+			}
+
 			.info-holder {
 				display: block;
 				padding: 15px;
@@ -369,6 +379,7 @@ h1 {
 			}
 		}
 	} 
+
 
 	
 

--- a/src/components/user-admin-selected.jsx
+++ b/src/components/user-admin-selected.jsx
@@ -4,9 +4,9 @@ import { apiGetInstancesForUser } from '../util/api'
 import UserAdminInstanceAvailable from './user-admin-instance-available'
 import UserAdminInstancePlayed from './user-admin-instance-played'
 
-const UserAdminSelected = ({user, selectedUser, onReturn}) => {
+const UserAdminSelected = ({selectedUser, currentUser, onReturn}) => {
 
-	const [updatedUser, setUpdatedUser] = useState({...user})
+	const [updatedUser, setUpdatedUser] = useState({...selectedUser})
 
 	const { data: widgets, isFetching: isLoadingWidgets} = useQuery({
 		queryKey: 'widgets',
@@ -22,7 +22,7 @@ const UserAdminSelected = ({user, selectedUser, onReturn}) => {
 	const instancesAvailable = isLoadingWidgets ? 
 		<span>Widgets are loading...</span> : 
 		widgets.instances_available?.map((instance, index) => {
-			return (<UserAdminInstanceAvailable instance={instance} key={index} />)
+			return (<UserAdminInstanceAvailable instance={instance} key={index} currentUser={currentUser}/>)
 		})
 
 	const instancesPlayed = isLoadingWidgets ? 

--- a/src/my-widgets.js
+++ b/src/my-widgets.js
@@ -10,6 +10,6 @@ export const queryClient = new QueryClient({ queryCache })
 ReactDOM.render(
 	<QueryClientProvider client={queryClient} contextSharing={true}>
 		<MyWidgetsPage />
-		<ReactQueryDevtools initialIsOpen={false} />
+		<ReactQueryDevtools initialIsOpen={true} />
 	</QueryClientProvider>, document.getElementById('app')
 )


### PR DESCRIPTION
This addresses Issue #1411. It adds the option to manage an instance from the list of user-owned or managed instances in the User Admin panel. 

- Copying a widget without granting access to original owners (which includes the searched user) will redirect you to your My Widgets Page
- Deleting a widget will refresh the user owned instances
- All other functions remain the same (Edit Widget brings you to the creator, Collaborate opens collaborate dialog, Apply changes will refresh the widget list)

![image](https://user-images.githubusercontent.com/46247315/211877341-7aa9d58f-7e37-4a89-9615-3d7b72d95ed6.png)
