### PR TITLE
Improved checks to $same_site config value

### DIFF
--- a/fuel/app/classes/materia/fuel/core/cookie.php
+++ b/fuel/app/classes/materia/fuel/core/cookie.php
@@ -42,7 +42,7 @@ class Cookie extends Fuel\Core\Cookie
 		is_null($http_only) and $http_only = static::$config['http_only'];
 		//static::$config is protected - can't get it in an extended class, hack workaround here
 		// FuelPHP casts $same_site as a string, which converts null into an empty string. Just using is_null is insufficient.
-		if ( is_null($same_site) || ! $same_site) $same_site = 'None';
+		if ( ! $same_site) $same_site = 'None';
 
 		// add the current time so we have an offset
 		$expiration = $expiration > 0 ? $expiration + time() : 0;

--- a/fuel/app/classes/materia/fuel/core/cookie.php
+++ b/fuel/app/classes/materia/fuel/core/cookie.php
@@ -41,7 +41,8 @@ class Cookie extends Fuel\Core\Cookie
 		// is_null($secure) and $secure = static::$config['secure'];
 		is_null($http_only) and $http_only = static::$config['http_only'];
 		//static::$config is protected - can't get it in an extended class, hack workaround here
-		is_null($same_site) and $same_site = 'None';
+		// FuelPHP casts $same_site as a string, which converts null into an empty string. Just using is_null is insufficient.
+		if ( is_null($same_site) || ! $same_site) $same_site = 'None';
 
 		// add the current time so we have an offset
 		$expiration = $expiration > 0 ? $expiration + time() : 0;
@@ -84,6 +85,9 @@ class Cookie extends Fuel\Core\Cookie
 	 */
 	public static function delete($name, $path = null, $domain = null, $secure = null, $http_only = null, $same_site = 'None')
 	{
+		// In case $same_site is an empty string, update its value to 'None', as intended
+		if ( ! $same_site) $same_site = 'None';
+
 		// Remove the cookie
 		unset($_COOKIE[$name]);
 


### PR DESCRIPTION
By default, `$same_site` is null in the core Fuel config, but Fuel later attempts to cast the value to a string, converting `null` into an empty string. The checks in our overriden `cookie` class don't catch the empty string value, so `sameSame='None'` did not get applied correctly. The cookie class will now check for an empty string value and update `$same_site` to `'None'` manually.