### PR TITLE
Updated comparison used in usort function to return an integer value

### DIFF
--- a/fuel/app/classes/materia/api/v1.php
+++ b/fuel/app/classes/materia/api/v1.php
@@ -692,7 +692,7 @@ class Api_V1
 		$summary = array_values($summary);
 		// we want to be sure that the client can rely on the array order
 		usort($summary, function($a, $b) {
-			return($a['id'] < $b['id']);
+			return($b['id'] - $a['id']);
 		});
 		return $summary;
 	}


### PR DESCRIPTION
`usort` will error out in PHP 8.1 when the callback function returns a boolean instead of an integer. Updated the callback function used in the API's `score_summary_get` method to return an integer value instead. 