### PR TITLE
Adds widget dependencies package

### DIFF
--- a/.github/workflows/publish_widget_dependencies.yml
+++ b/.github/workflows/publish_widget_dependencies.yml
@@ -1,5 +1,6 @@
 name: Upload Widget Dependencies Package
-on: workflow_dispatch
+on:
+  workflow_dispatch:
 jobs:
   checkout-and-install:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_widget_dependencies.yml
+++ b/.github/workflows/publish_widget_dependencies.yml
@@ -1,0 +1,16 @@
+name: Upload Widget Dependencies Package
+on: workflow_dispatch
+jobs:
+  checkout-and-install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.13.0'
+          registry-url: 'https://registry.npmjs.org'
+      - run: yarn install
+      - run: yarn build
+      - run: yarn publish public/dist
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -116,5 +116,9 @@ licenses/LICENSES_NPM
 materia-pkg.zip
 materia-pkg-build-info.yml
 
-public/dist
 yarn-error.log
+
+public/dist/*
+!public/dist/package.json
+!public/dist/README.md
+!public/dist/path.js

--- a/.gitignore
+++ b/.gitignore
@@ -121,4 +121,3 @@ yarn-error.log
 public/dist/*
 !public/dist/package.json
 !public/dist/README.md
-!public/dist/path.js

--- a/public/dist/README.md
+++ b/public/dist/README.md
@@ -1,0 +1,10 @@
+# Materia Widget Dependencies
+
+This package is intended for use by [Materia](https://github.com/ucfopen/Materia), an open-source platform for interactive educational games and tools developed by the University of Central Florida.
+
+With Materia 10.0 and the conversion from AngularJS to React, the **Materia-Server-Client-Assets** repo is deprecated, but the Materia Widget Development Kit still requires access to certain CSS and JS assets from the main repo. This package contains those assets.
+
+## TODOS:
+
+- Include JS and CSS assets required to render the Materia player and creator in the MWDK.
+- Update the MWDK to Webpack 5 and add support for new JS and CSS assets provided in this package.

--- a/public/dist/README.md
+++ b/public/dist/README.md
@@ -4,7 +4,16 @@ This package is intended for use by [Materia](https://github.com/ucfopen/Materia
 
 With Materia 10.0 and the conversion from AngularJS to React, the **Materia-Server-Client-Assets** repo is deprecated, but the Materia Widget Development Kit still requires access to certain CSS and JS assets from the main repo. This package contains those assets.
 
-## TODOS:
+### Publishing New Versions
 
-- Include JS and CSS assets required to render the Materia player and creator in the MWDK.
-- Update the MWDK to Webpack 5 and add support for new JS and CSS assets provided in this package.
+This widget uses the `workflow_dispatch` event to publish new versions through GitHub Actions. No inputs are required. The action is configured to be publish the package to NPM, and as such, the `NPM_TOKEN` value must be available in the repository's secrets. If the `workflow_dispatch` option is unavailable, you can use GitHub CLI to run the workflow manually via:
+
+```
+gh workflow run publish_widget_dependencies.yml
+```
+
+If on a branch other than master, you can additionally specify the branch in the command:
+
+```
+gh workflow run publish_widget_dependencies.yml --ref <branch name>
+```

--- a/public/dist/package.json
+++ b/public/dist/package.json
@@ -7,10 +7,16 @@
 		"js/materia.enginecore.js",
 		"js/materia.creatorcore.js",
 		"js/materia.scorecore.js",
-        "js/player-page.js",
-        "js/creator-page.js"
+		"js/player-page.js",
+		"js/player-page.css",
+		"js/creator-page.js",
+		"js/creator-page.css",
+		"js/qset-history.js",
+		"js/qset-history.css",
+		"js/question-importer.js",
+		"js/question-importer.css"
 	],
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/clpetersonucf/Materia"

--- a/public/dist/package.json
+++ b/public/dist/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "materia-widget-dependencies",
+	"description": "The Widget Dependencies package provides js and css assets from Materia that are required for proper functioning of the Widget Development Kit.",
+	"author": "University of Central Florida, Center for Distributed Learning",
+	"license": "AGPL-3.0",
+	"files": [
+		"js/materia.enginecore.js",
+		"js/materia.creatorcore.js",
+		"js/materia.scorecore.js",
+        "js/player-page.js",
+        "js/creator-page.js"
+	],
+	"version": "0.0.4",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/clpetersonucf/Materia"
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,7 +61,7 @@ module.exports = {
 		filename: '[name].js',
 		clean: {
 			keep(asset) {
-				return (asset.includes('package.json') || asset.includes('README.md') || asset.includes('path.js'))
+				return (asset.includes('package.json') || asset.includes('README.md'))
 			}
 		}
 	},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,9 +59,10 @@ module.exports = {
 	output: {
 		path: path.join(__dirname, 'public/dist/'),
 		filename: '[name].js',
-		clean: true,
-		keep(asset) {
-			return (asset.includes('package.json') || asset.includes('README.md') || asset.includes('path.js'))
+		clean: {
+			keep(asset) {
+				return (asset.includes('package.json') || asset.includes('README.md') || asset.includes('path.js'))
+			}
 		}
 	},
 	module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,7 +59,10 @@ module.exports = {
 	output: {
 		path: path.join(__dirname, 'public/dist/'),
 		filename: '[name].js',
-		clean: true
+		clean: true,
+		keep(asset) {
+			return (asset.includes('package.json') || asset.includes('README.md') || asset.includes('path.js'))
+		}
 	},
 	module: {
 		rules: [


### PR DESCRIPTION
This is an attempt to resolve the co-dependency issue with the widget dev kit requiring certain assets from Materia itself in order to run widgets in situ. Since the assets are no longer housed in an independent repo (previously Materia-Server-Client-Assets), it made sense to create a node package that's published from within Materia itself.

The `materia-widget-dependencies-package` is housed in `public/dist`, a previously untracked directory where webpack is currently configured to emit compiled assets. Nothing in `public/dist` is tracked with the exception of the new `package.json` and accompanying README. There are no dependencies specific to MWDP, it merely contains a manifest of previously compiled JS and CSS assets for use in the dev kit. To publish the package, a new GitHub action is included to make use of `workflow_dispatch`, which means publish events are triggered manually and not tied to any CI/CD process.