### PR TITLE
Resolves ZipArchive deprecated references

### DIFF
--- a/fuel/app/classes/materia/session/playdataexporter.php
+++ b/fuel/app/classes/materia/session/playdataexporter.php
@@ -334,7 +334,7 @@ class Session_PlayDataExporter
 		$tempname = tempnam('/tmp', 'materia_raw_log_csv');
 
 		$zip = new \ZipArchive();
-		$zip->open($tempname);
+		$zip->open($tempname, \ZipArchive::OVERWRITE);
 		$zip->addFromString('questions.csv', $csv_question_text);
 		$zip->addFromString('answers.csv', $csv_answer_text);
 		$zip->addFromString('logs.csv', $csv_playlog_text);
@@ -426,7 +426,7 @@ class Session_PlayDataExporter
 		$tempname = tempnam('/tmp', 'materia_raw_log_csv');
 
 		$zip = new \ZipArchive();
-		$zip->open($tempname);
+		$zip->open($tempname, \ZipArchive::OVERWRITE);
 		$zip->addFromString('individual_referrers.csv', $csv_i);
 		$zip->addFromString('collective_referrers.csv', $csv_c);
 		$zip->close();


### PR DESCRIPTION
Fixes #1444 by adding `ZipArchive::OVERWRITE` to `$zip->open($temname);` references in the `Session_PlayDataExporter` class. Note that widgets that have custom export options will also need this change implemented in their own play data exporters.