### PR TITLE
Issue/1438 Grants support users additional permissions

### DIFF
--- a/fuel/app/classes/materia/perm/manager.php
+++ b/fuel/app/classes/materia/perm/manager.php
@@ -665,9 +665,9 @@ class Perm_Manager
 
 		$all_perms = self::get_all_users_with_perms_to($object_id, $object_type);
 
-		// if the current user is a super user, append their user's perms into the results
-		// super users don't get explicit perms to things set in the db, so we'll fake it here
-		$cur_user_perms = self::is_super_user() ? [Perm::SUPERUSER, null] : $all_perms[$current_user_id];
+		// if the current user is a super user or support user, append their user's perms into the results
+		// super users and support users don't get explicit perms to objects set in the db, so we'll fake it here
+		$cur_user_perms = self::is_super_user() ? [Perm::SUPERUSER, null] : (self::is_support_user() ? [Perm::FULL, null] : $all_perms[$current_user_id]);
 
 		return [
 			'user_perms' => [$current_user_id => $cur_user_perms],

--- a/fuel/app/classes/model/user.php
+++ b/fuel/app/classes/model/user.php
@@ -94,6 +94,7 @@ class Model_User extends Orm\Model
 		$user_table = \Model_User::table();
 		$matches = \DB::select()
 			->from($user_table)
+			// Do not return super users or the current user
 			->where($user_table.'.id', 'NOT', \DB::expr('IN('.\DB::select($user_table.'.id')
 				->from($user_table)
 				->join('perm_role_to_user', 'LEFT')

--- a/fuel/app/migrations/053_add_support_user_role_perms.php
+++ b/fuel/app/migrations/053_add_support_user_role_perms.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Fuel\Migrations;
+
+class Add_support_user_role_perms
+{
+	public function up()
+	{
+        $support_role_id = \Materia\Perm_Manager::get_role_id('support_user');
+
+        \DB::query('INSERT INTO `perm_role_to_perm` SET `role_id` = :role_id, `perm` = :perm ON DUPLICATE KEY UPDATE `perm` = :perm')
+            ->param('role_id', $support_role_id)
+			->param('perm', \Materia\Perm::FULL)
+            ->execute();
+	}
+
+	public function down()
+	{
+        $support_role_id = \Materia\Perm_Manager::get_role_id('support_user');
+        
+        \DB::delete('perm_role_to_perm')
+            ->where('role_id', 'like', $support_role_id)
+            ->execute();
+	}
+}

--- a/fuel/app/migrations/054_add_support_user_role_perms.php
+++ b/fuel/app/migrations/054_add_support_user_role_perms.php
@@ -10,14 +10,14 @@ class Add_support_user_role_perms
 
         \DB::query('INSERT INTO `perm_role_to_perm` SET `role_id` = :role_id, `perm` = :perm ON DUPLICATE KEY UPDATE `perm` = :perm')
             ->param('role_id', $support_role_id)
-			->param('perm', \Materia\Perm::FULL)
+            ->param('perm', \Materia\Perm::FULL)
             ->execute();
 	}
 
 	public function down()
 	{
         $support_role_id = \Materia\Perm_Manager::get_role_id('support_user');
-        
+
         \DB::delete('perm_role_to_perm')
             ->where('role_id', 'like', $support_role_id)
             ->execute();

--- a/fuel/app/tasks/admin.php
+++ b/fuel/app/tasks/admin.php
@@ -306,6 +306,15 @@ class Admin extends \Basetask
 			$q->param('perm', \Materia\Perm::AUTHORACCESS);
 			$q->execute();
 		}
+		
+		if ($support_role_id = \Materia\Perm_Manager::get_role_id('support_user'))
+		{
+			$q = \DB::query('INSERT INTO `perm_role_to_perm` SET `role_id` = :role_id, `perm` = :perm ON DUPLICATE KEY UPDATE `perm` = :perm');
+
+			$q->param('role_id', $support_role_id);
+			$q->param('perm', \Materia\Perm::FULL);
+			$q->execute();
+		}
 
 		\Cli::write(\Cli::color("Roles Added: $roles", 'green'));
 	}

--- a/src/components/my-widgets-collaborate-dialog.jsx
+++ b/src/components/my-widgets-collaborate-dialog.jsx
@@ -56,7 +56,10 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 	// Sets Perms
 	useEffect(() => {
 		const map = new Map(otherUserPerms)
-		map.forEach(key => key.remove = false)
+		map.forEach((key, pair) => {
+			key.remove = false
+			pair = pair.toString()
+		})
 		setState({...state, updatedOtherUserPerms: map})
 	}, [otherUserPerms])
 
@@ -80,7 +83,7 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 
 			// Updateds the perms
 			tempPerms.set(
-				match.id,
+				match.id.toString(),
 				{
 					accessLevel: 1,
 					expireTime: null,
@@ -163,7 +166,7 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 
 	const updatePerms = (userId, perms) => {
 		let newPerms = new Map(state.updatedOtherUserPerms)
-		newPerms.set(userId, perms)
+		newPerms.set(userId.toString(), perms)
 		setState({...state, updatedOtherUserPerms: newPerms})
 	}
 

--- a/src/components/my-widgets-settings-dialog.jsx
+++ b/src/components/my-widgets-settings-dialog.jsx
@@ -251,7 +251,6 @@ const MyWidgetsSettingsDialog = ({ onClose, inst, currentUser, otherUserPerms, o
 			mutateWidget.mutate({
 				args: args,
 				successFunc: (updatedInst) => {
-					console.log(updatedInst)
 					onEdit(updatedInst)
 					if (mounted.current) {
 						onClose()


### PR DESCRIPTION
Issue #1438 

After digging around, the lowest tier of access I could find that allows users to edit widget settings and grant access to other users was ownership permissions, or Perm::FULL. I could be wrong about this, so let me know what you think!

### NOTE: This PR includes a migration.

This PR also fixes an issue in the Collaborate dialog where users would appear more than once in the search results.

