### PR TITLE
Perms definitions update

### DIFF
--- a/fuel/app/classes/materia/perm.php
+++ b/fuel/app/classes/materia/perm.php
@@ -62,10 +62,10 @@ abstract class Perm
 	const GIVE_SHARE   = 75;
 
 	// group rights only
-	/** @const Has rights to access manger interface */
-	const AUTHORACCESS  = 80;
-	/** @const Has rights to administer users */
-	const ADMINISTRATOR = 85;
-	/** @const Has super user rights to do anything */
+	/** @const Standard author access level. Can edit/publish/modify and share widgets without restrictions. */
+	const BASICAUTHOR  = 80;
+	/** @const Elevated access level. Grants access to instance and user admin interface. Can review user settings, ownership, and play history, and access/modify instances and their settings. */
+	const SUPPORTUSER = 85;
+	/** @const Super-elevated access level. Can do anything. */
 	const SUPERUSER     = 90;
 }

--- a/fuel/app/classes/materia/perm/manager.php
+++ b/fuel/app/classes/materia/perm/manager.php
@@ -589,7 +589,7 @@ class Perm_Manager
 	/**
 	 * Gets an array of object ids that a user has permissions to access EXCLUSIVELY based on an elevated role
 	 * This requires the user has a role with elevated perms, and that the group rights associated with those perms are present in the perm_role_to_perm table
-	 * Currently, the role must be Perm::ADMINISTRATOR or Perm::SUPERUSER
+	 * Currently, the role must be Perm::SUPPORTUSER or Perm::SUPERUSER
 	 * 
 	 * Perm_Manager->get_all_objects_for_users($user->user_id, \Materia\Perm::INSTANCE);
 	 *
@@ -615,10 +615,10 @@ class Perm_Manager
 
 		
 		// verify that perms returned from perm_role_to_perm table are elevated
-		// this means either Perm::ADMINISTRATOR (85) or Perm::SUPERUSER (90)
+		// this means either Perm::SUPPORTUSER (85) or Perm::SUPERUSER (90)
 		foreach ($roles_perms as $role)
 		{
-			if (in_array([Perm::ADMINISTRATOR, Perm::SUPERUSER], $role['perm'])) $user_is_admin_or_su = true;
+			if (in_array([Perm::SUPPORTUSER, Perm::SUPERUSER], $role['perm'])) $user_is_admin_or_su = true;
 		}
 
 		if ($user_is_admin_or_su == true)

--- a/fuel/app/migrations/054_add_support_user_role_perms.php
+++ b/fuel/app/migrations/054_add_support_user_role_perms.php
@@ -6,20 +6,24 @@ class Add_support_user_role_perms
 {
 	public function up()
 	{
-        $support_role_id = \Materia\Perm_Manager::get_role_id('support_user');
+		$support_role_id = \Materia\Perm_Manager::get_role_id('support_user');
 
-        \DB::query('INSERT INTO `perm_role_to_perm` SET `role_id` = :role_id, `perm` = :perm ON DUPLICATE KEY UPDATE `perm` = :perm')
-            ->param('role_id', $support_role_id)
-            ->param('perm', \Materia\Perm::FULL)
-            ->execute();
+		$q = \DB::query('INSERT INTO `perm_role_to_perm` SET `role_id` = :role_id, `perm` = :perm ON DUPLICATE KEY UPDATE `perm` = :perm');
+		$q->param('role_id', $support_role_id);
+		$q->param('perm', \Materia\Perm::FULL);
+		$q->execute();
+
+		$q->param('role_id', $support_role_id);
+		$q->param('perm', \Materia\Perm::SUPPORTUSER);
+		$q->execute();
 	}
 
 	public function down()
 	{
-        $support_role_id = \Materia\Perm_Manager::get_role_id('support_user');
+		$support_role_id = \Materia\Perm_Manager::get_role_id('support_user');
 
-        \DB::delete('perm_role_to_perm')
-            ->where('role_id', 'like', $support_role_id)
-            ->execute();
+		\DB::delete('perm_role_to_perm')
+			->where('role_id', 'like', $support_role_id)
+			->execute();
 	}
 }

--- a/fuel/app/migrations/054_add_support_user_role_perms.php
+++ b/fuel/app/migrations/054_add_support_user_role_perms.php
@@ -8,14 +8,35 @@ class Add_support_user_role_perms
 	{
 		$support_role_id = \Materia\Perm_Manager::get_role_id('support_user');
 
-		$q = \DB::query('INSERT INTO `perm_role_to_perm` SET `role_id` = :role_id, `perm` = :perm ON DUPLICATE KEY UPDATE `perm` = :perm');
-		$q->param('role_id', $support_role_id);
-		$q->param('perm', \Materia\Perm::FULL);
-		$q->execute();
+		// check to see if support_user already has Perm::FULL
+		$pre_q = \DB::select('role_id','perm')
+			->from('perm_role_to_perm')
+			->where('role_id', $support_role_id)
+			->where('perm', \Materia\Perm::FULL)
+			->execute();
+		
+		// if not, grant support_user Perm::FULL
+		if ($pre_q->count() == 0) {
+			$q = \DB::query('INSERT INTO `perm_role_to_perm` (`role_id`, `perm`) values (:role_id, :perm) ON DUPLICATE KEY UPDATE `role_id` = :role_id, `perm` = :perm');
+			$q->param('role_id', $support_role_id);
+			$q->param('perm', \Materia\Perm::FULL);
+			$q->execute();
+		}
 
-		$q->param('role_id', $support_role_id);
-		$q->param('perm', \Materia\Perm::SUPPORTUSER);
-		$q->execute();
+		// now check to see if support_user already has Perm::SUPPORTUSER
+		$pre_q = \DB::select('role_id','perm')
+			->from('perm_role_to_perm')
+			->where('role_id', $support_role_id)
+			->where('perm', \Materia\Perm::SUPPORTUSER)
+			->execute();
+
+		// if not, grant support_user Perm::SUPPORTUSER
+		if ($pre_q->count() == 0) {
+			$q = \DB::query('INSERT INTO `perm_role_to_perm` (`role_id`, `perm`) values (:role_id, :perm) ON DUPLICATE KEY UPDATE `role_id` = :role_id, `perm` = :perm');
+			$q->param('role_id', $support_role_id);
+			$q->param('perm', \Materia\Perm::SUPPORTUSER);
+			$q->execute();
+		}
 	}
 
 	public function down()

--- a/fuel/app/migrations/055_update_super_user_role_permissions.php
+++ b/fuel/app/migrations/055_update_super_user_role_permissions.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Fuel\Migrations;
+
+class Update_super_user_role_permissions
+{
+	public function up()
+	{
+		$super_user_role_id = \Materia\Perm_Manager::get_role_id('super_user');
+
+		\DB::QUERY('UPDATE `perm_role_to_perm` SET `perm` = :new_perm WHERE `role_id` = :role_id AND `perm` = :old_perm')
+			->param('role_id', $super_user_role_id)
+			->param('old_perm', \Materia\Perm::BASICAUTHOR) // the OLD permission level (80)
+			->param('new_perm', \Materia\Perm::SUPERUSER)   // the NEW permission level (90)
+			->execute();
+	}
+
+	public function down()
+	{
+		$super_user_role_id = \Materia\Perm_Manager::get_role_id('super_user');
+
+		\DB::QUERY('UPDATE `perm_role_to_perm` SET `perm` = :old_perm WHERE `role_id` = :role_id AND `perm` = :new_perm')
+			->param('role_id', $super_user_role_id)
+			->param('old_perm', \Materia\Perm::BASICAUTHOR)
+			->param('new_perm', \Materia\Perm::SUPERUSER)
+			->execute();
+	}
+}

--- a/fuel/app/tasks/admin.php
+++ b/fuel/app/tasks/admin.php
@@ -303,7 +303,7 @@ class Admin extends \Basetask
 			$q->execute();
 
 			$q->param('role_id', $admin_role_id);
-			$q->param('perm', \Materia\Perm::AUTHORACCESS);
+			$q->param('perm', \Materia\Perm::SUPERUSER);
 			$q->execute();
 		}
 		
@@ -313,6 +313,10 @@ class Admin extends \Basetask
 
 			$q->param('role_id', $support_role_id);
 			$q->param('perm', \Materia\Perm::FULL);
+			$q->execute();
+
+			$q->param('role_id', $support_role_id);
+			$q->param('perm', \Materia\Perm::SUPPORTUSER);
 			$q->execute();
 		}
 


### PR DESCRIPTION
There's a lot of inconsistencies with group level permissions in the master branch:

- Group level permissions are defined but not really used except in one or two instances
- Group level permission definitions do not match current roles
- Group level permissions (espcially for superusers) are applied nonsensically

To fix this, this PR:

- Redefines the group level definitions to match current user roles
- Applies group level definitions to `support_user` where they did not exist on the react branch previously
- Updates the superuser permission level to the correct value