### PR TITLE
Accessibility indicator polish

### DIFF
--- a/fuel/app/classes/controller/admin.php
+++ b/fuel/app/classes/controller/admin.php
@@ -21,9 +21,9 @@ class Controller_Admin extends Controller
 	{
 		if ( ! \Materia\Perm_Manager::is_super_user() ) throw new \HttpNotFoundException;
 	
-		JS::push_inline('var UPLOAD_ENABLED ="'.Config::get('materia.enable_admin_uploader').'";');
-		JS::push_inline('var HEROKU_WARNING ="'.Config::get('materia.heroku_admin_warning').'";');
-		JS::push_inline('var ACTION_LINK ="/admin/upload";');
+		Js::push_inline('var UPLOAD_ENABLED ="'.Config::get('materia.enable_admin_uploader').'";');
+		Js::push_inline('var HEROKU_WARNING ="'.Config::get('materia.heroku_admin_warning').'";');
+		Js::push_inline('var ACTION_LINK ="/admin/upload";');
 		Js::push_inline('var UPLOAD_NOTICE = "'.Session::get_flash('upload_notice').'";');
 
 		$this->theme = Theme::instance();

--- a/src/components/catalog-card.jsx
+++ b/src/components/catalog-card.jsx
@@ -40,13 +40,13 @@ const CatalogCard = ({
 
 	if(isValidAccessVal(meta_data.accessibility_keyboard)) {
 		featuresRender.push(
-			<li className='accessibility-status'><KeyboardIcon color='#000'/>{`${meta_data.accessibility_keyboard}`} Support</li>
+			<li className={`accessibility-status ${activeFilters.includes('Keyboard Accessible') ? 'selected' : ''}`}><KeyboardIcon color='#000'/>{`${meta_data.accessibility_keyboard}`} Support</li>
 		)
 	}
 
 	if(isValidAccessVal(meta_data.accessibility_reader)) {
 		featuresRender.push(
-			<li className='accessibility-status'><ScreenReaderIcon color='#000'/>{`${meta_data.accessibility_reader}`} Support</li>
+			<li className={`accessibility-status ${activeFilters.includes('Screen Reader Accessible') ? 'selected' : ''}`}><ScreenReaderIcon color='#000'/>{`${meta_data.accessibility_reader}`} Support</li>
 		)
 	}
 

--- a/src/components/catalog-card.jsx
+++ b/src/components/catalog-card.jsx
@@ -38,30 +38,16 @@ const CatalogCard = ({
 		<li className={`${activeFilters.includes(filter) ? 'selected' : ''}`} title={filter} key={filter}>{filter}</li>
 	)
 
-	let keyboardIconRender = null
-	let readerIconRender = null
-
 	if(isValidAccessVal(meta_data.accessibility_keyboard)) {
-		keyboardIconRender = <div>
-			<KeyboardIcon color={`${activeFilters.includes('Keyboard Accessible') ? '#3498db' : 'black'}`}/>
-			<span aria-label='keyboard-access-popup' className='tool-tip'>Keyboard Accessible</span>
-		</div>
-	}
-	if(isValidAccessVal(meta_data.accessibility_reader)) {
-		readerIconRender = <div aria-label='screen-reader-access-icon'>
-			<ScreenReaderIcon color={`${activeFilters.includes('Screen Reader Accessible') ? '#3498db' : 'black'}`}/>
-			<span aria-label='screen-reader-access-popup' className='tool-tip'>Screen Reader Accessible</span>
-		</div>
+		featuresRender.push(
+			<li className='accessibility-status'><KeyboardIcon color='#000'/>{`${meta_data.accessibility_keyboard}`} Support</li>
+		)
 	}
 
-	let accessibilityRender = null
-	if ( keyboardIconRender || readerIconRender) {
-		accessibilityRender = <div className='accessibility-holder'>
-			<div className='accessibility-indicators'>
-				{ keyboardIconRender }
-				{ readerIconRender }
-			</div>
-		</div>
+	if(isValidAccessVal(meta_data.accessibility_reader)) {
+		featuresRender.push(
+			<li className='accessibility-status'><ScreenReaderIcon color='#000'/>{`${meta_data.accessibility_reader}`} Support</li>
+		)
 	}
 
 	return (
@@ -87,7 +73,6 @@ const CatalogCard = ({
 						{ supportedDataRender }
 						{ featuresRender }
 					</ul>
-					{ accessibilityRender }
 				</div>
 			</a>
 		</div>

--- a/src/components/catalog.jsx
+++ b/src/components/catalog.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useMemo } from 'react'
 import CatalogCard from './catalog-card'
+import KeyboardIcon from './keyboard-icon'
+import ScreenReaderIcon from './screen-reader-icon'
 import './catalog.scss'
 
 const isMobileDevice = () => window.matchMedia('(max-width: 720px)').matches
@@ -119,6 +121,8 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 				className={'feature-button' + (isEnabled ? ' selected' : '')}
 				aria-hidden={!state.showingFilters}
 				onClick={ filterOptionClickHandler }>
+				{ filter == 'Keyboard Accessible' ? <KeyboardIcon color='#000' /> : '' }
+				{ filter == 'Screen Reader Accessible' ? <ScreenReaderIcon color='#000' /> : '' }
 				{filter}
 			</button>
 		}

--- a/src/components/catalog.scss
+++ b/src/components/catalog.scss
@@ -175,6 +175,12 @@
 						background: #3498db;
 						color: white;
 					}
+
+					svg {
+						width: 16px;
+						height: auto;
+						margin-right: 6px;
+					}
 				}
 			}
 		}
@@ -395,6 +401,14 @@
 						&.selected {
 							background: #3498db;
 							color: white;
+						}
+
+						&.accessibility-status {
+							svg {
+								width: 12px;
+								height: auto;
+								margin-right: 6px;
+							}
 						}
 					}
 				}

--- a/src/components/catalog.scss
+++ b/src/components/catalog.scss
@@ -173,7 +173,11 @@
 
 					&.selected {
 						background: #3498db;
-						color: white;
+						color: #fff;
+
+						svg {
+							fill: #fff;
+						}
 					}
 
 					svg {
@@ -401,6 +405,10 @@
 						&.selected {
 							background: #3498db;
 							color: white;
+
+							&.accessibility-status svg {
+								fill: #fff;
+							}
 						}
 
 						&.accessibility-status {

--- a/src/components/detail.scss
+++ b/src/components/detail.scss
@@ -44,6 +44,20 @@ $color-green: #c5dd60;
 	flex-direction: column;
 	margin-bottom: 12px;
 
+	// padding-left: 10px;
+
+	// &:nth-child(1) {
+	// 	border-left: 8px solid rgba(239, 129, 82, 0.5);
+	// }
+
+	// &:nth-child(2) {
+	// 	border-left: 8px solid rgba(117, 191, 91, 0.5);
+	// }
+
+	// &:nth-child(3) {
+	// 	border-left: 8px solid rgba(93, 163, 203, 0.5);
+	// }
+
 	&:last-of-type {
 		margin-bottom: 0;
 	}
@@ -66,6 +80,7 @@ $color-green: #c5dd60;
 					.icon-spacer {
 						display: inline-block;
 						width: 35px;
+						margin-right: 10px;
 
 						svg {
 							position: relative;
@@ -75,28 +90,8 @@ $color-green: #c5dd60;
 					}
 
 					span {
-						color: #525252;
-						font-size: 14px;
-					}
-
-					.highlighted {
-						color: white;
-						background-color: $color-red;
-						font-weight: bold;
-						justify-content: center;
-						padding: 3px 6px;
-						border-radius: 5px;
-						box-shadow: 1px 2px 1px rgba(146, 146, 146, 0.8);
-
-						&.full {
-							color: #525252;
-							background-color: $color-green;
-						}
-
-						&.limited {
-							color: #525252;
-							background-color: $color-yellow;
-						}
+						color: #000;
+						font-size: 16px;
 					}
 				}
 			}
@@ -105,6 +100,7 @@ $color-green: #c5dd60;
 
 	.feature-heading {
 		font-size: 14px;
+		// font-weight: 700;
 		margin-bottom: 6px;
 
 		&.guide {
@@ -255,7 +251,7 @@ $color-green: #c5dd60;
 			border-radius: 2px;
 			background: $color-features;
 			color: #fff;
-			padding: 2px 6px;
+			padding: 4px 12px;
 			margin-right: 5px;
 
 			font-weight: 700;
@@ -450,8 +446,8 @@ a {
 		background: #eee;
 		border-radius: 4px 4px 0 0;
 		color: #333;
-		padding: 25px 20px;
-		min-height: 65px;
+		padding: 15px 15px;
+		min-height: 92px;
 
 		img {
 			height: 92px;

--- a/src/components/detail.scss
+++ b/src/components/detail.scss
@@ -44,20 +44,6 @@ $color-green: #c5dd60;
 	flex-direction: column;
 	margin-bottom: 12px;
 
-	// padding-left: 10px;
-
-	// &:nth-child(1) {
-	// 	border-left: 8px solid rgba(239, 129, 82, 0.5);
-	// }
-
-	// &:nth-child(2) {
-	// 	border-left: 8px solid rgba(117, 191, 91, 0.5);
-	// }
-
-	// &:nth-child(3) {
-	// 	border-left: 8px solid rgba(93, 163, 203, 0.5);
-	// }
-
 	&:last-of-type {
 		margin-bottom: 0;
 	}


### PR DESCRIPTION
- Accessibility indicators in the catalog are refined, they now populate alongside supported data and features.
- Added accessibility icons to the filter options to better associate them.
- Small adjustments to indicator & detail page styles.

Accessibility status is displayed when requisite data is present in the widget's `install.yaml` metadata section upon install:

```
metadata:
    accessibility_keyboard: Full # values can be Full | Limited | None
    accessibility_reader: Full
```