### PR TITLE
Adds postMessage call on successful widget selection in LTI picker.

### DIFF
--- a/src/components/lti/select-item.jsx
+++ b/src/components/lti/select-item.jsx
@@ -26,7 +26,7 @@ const SelectItem = () => {
 		onSuccess: (data) => {
 			if (data) {
 				data.pagination.map((instance, index) => {
-					instance.img = iconUrl('/widget/', instance.widget.dir, 60)
+					instance.img = iconUrl(BASE_URL + 'widget/', instance.widget.dir, 60)
 					instance.preview_url = BASE_URL + 'preview/' + instance.id
 					instance.edit_url = BASE_URL + 'my-widgets/#' + instance.id
 				})
@@ -83,6 +83,10 @@ const SelectItem = () => {
 			let pgSpan = document.querySelector('.progress-container span')
 			pg.classList.add('success')
 			pgSpan.innerText = 'Success!'
+
+			if (JSON.stringify && parent.postMessage) {
+				parent.postMessage(JSON.stringify(selectedInstance), '*')
+			}
 
 			if (!!window.RETURN_URL) {
 				// add a ? or & depending on window.RETURN_URL already containing query params
@@ -143,7 +147,7 @@ const SelectItem = () => {
 				if (instance.selected) classList.push('selected')
 				if (instance.guest_access) classList.push('guest')
 				if (hiddenSet.has(instance.id)) classList.push('hidden')
-	
+
 				return <li className={classList.join(' ')} key={index}>
 					<div className={`widget-info ${instance.is_draft ? 'draft' : ''} ${instance.guest_access ? 'guest' : ''}`}>
 						<img className="widget-icon" src={instance.img}/>


### PR DESCRIPTION
Closes #1474.

Adds a `parent.postMessage` call in support of Obojobo or other platforms which may rely on it.

Changes widget icon URL to be absolute rather than relative for the benefit of said platforms.