### PR TITLE
Fixes to notifications and collaborator

### DIFF
--- a/fuel/app/classes/model/user.php
+++ b/fuel/app/classes/model/user.php
@@ -94,7 +94,7 @@ class Model_User extends Orm\Model
 		$user_table = \Model_User::table();
 		$matches = \DB::select()
 			->from($user_table)
-			// Do not return super users or the current user
+			// Do not return super users or the current user // << why?
 			->where($user_table.'.id', 'NOT', \DB::expr('IN('.\DB::select($user_table.'.id')
 				->from($user_table)
 				->join('perm_role_to_user', 'LEFT')

--- a/src/components/my-widgets-collaborate-user-row.jsx
+++ b/src/components/my-widgets-collaborate-user-row.jsx
@@ -143,8 +143,8 @@ const CollaborateUserRow = ({user, perms, myPerms, isCurrentUser, onChange, read
 			<button tabIndex='0'
 				onClick={checkForWarning}
 				className='remove'
-				disabled={readOnly && !isCurrentUser || myPerms.accessLevel == access.VISIBLE}
-				aria-hidden={readOnly && !isCurrentUser || myPerms.accessLevel == access.VISIBLE}
+				disabled={readOnly && !isCurrentUser}
+				aria-hidden={readOnly && !isCurrentUser}
 				data-testid={`${user.id}-delete-user`}>
 				X
 			</button>

--- a/src/components/notifications.jsx
+++ b/src/components/notifications.jsx
@@ -24,7 +24,10 @@ const Notifications = (user) => {
 		queryFn: apiGetNotifications,
         staleTime: Infinity,
         onSuccess: (data) => {
-            numNotifications.current = data.length;
+            numNotifications.current = 0;
+            if (data && data.length > 0) data.forEach(element => {
+                if (!element.remove) numNotifications.current++;
+            });
         }
     })
 


### PR DESCRIPTION
* In the case where a user sends an access request twice and the recipient grants them Full Access in one notification, and then grants them View Scores access in the next notification (or vice versa) without leaving the page, the collaborator dialog will still show the user as having Full Access. Just needed to reverse the merge priority when creating a JavaScript map from otherUserPerms and state.updatedAllUserPerms.
* Fixes notification count on envelope icon not decrementing after granting a user access.
* Removes leftover code from from testing the setQueryData
* Users can now remove themselves as collaborators regardless of their level of access.