### PR TITLE
Catalog accessibility indicator updates

### DIFF
--- a/src/components/accessibility-indicator.jsx
+++ b/src/components/accessibility-indicator.jsx
@@ -15,12 +15,20 @@ const AccessibilityIndicator = ({widget = {}}) => {
 		}
 	}
 
+	let descriptionRender = ''
+	if (widget.accessibility.keyboard.toLowerCase() != 'unavailable' || widget.accessibility.screen_reader.toLowerCase() != 'unavailable') {
+		descriptionRender = widget.accessibility.description
+	}
+	else {
+		descriptionRender = 'No accessibility information is provided for this widget.'
+	}
+
 	return (
 		<div className='feature-list accessibility-options'>
 			<div className='list-holder'>
 				<span className='feature-heading'>Accessibility:</span>
 				<ul>
-					<li>
+					<li className={`accessibility-indicator ${widget.accessibility?.keyboard.toLowerCase() != 'unavailable' ? 'show' : ''}`}>
 						<div className='icon-spacer'>
 							<KeyboardIcon color='#5a5a5a'/>
 						</div>
@@ -30,15 +38,18 @@ const AccessibilityIndicator = ({widget = {}}) => {
 							</span>
 						</span>
 					</li>
-					<li>
+					<li className={`accessibility-indicator ${widget.accessibility?.screen_reader.toLowerCase() != 'unavailable' ? 'show' : ''}`}>
 						<div className='icon-spacer'>
 							<ScreenReaderIcon color='#5a5a5a'/>
 						</div>
-						<span>Screen reader is&nbsp;
+						<span>Screen readers are&nbsp;
 							<span id='screen-reader-access-level' className={`highlighted ${widget.accessibility?.screen_reader.toLowerCase()}`}>
 								{`${accessLevelToText(widget.accessibility?.screen_reader)} supported`}
 							</span>
 						</span>
+					</li>
+					<li className={`accessibility-description ${descriptionRender.length > 0 ? 'show' : ''}`}>
+						{descriptionRender}
 					</li>
 				</ul>
 			</div>

--- a/src/components/catalog.jsx
+++ b/src/components/catalog.jsx
@@ -155,7 +155,9 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 		const filterOptionClickHandler = () => toggleFilter(filter)
 		return <button key={index}
 				className={'feature-button' + (isEnabled ? ' selected' : '')}
+				aria-label={`Filter by ${filter}. ${isEnabled ? 'Selected.' : ''}`}
 				aria-hidden={!state.showingFilters}
+				disabled={!state.showingFilters}
 				onClick={ filterOptionClickHandler }>
 				{filter}
 			</button>
@@ -167,7 +169,9 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 		const filterOptionClickHandler = () => toggleFilter(filter)
 		return <button key={index}
 				className={'feature-button' + (isEnabled ? ' selected' : '')}
-				aria-hidden={!state.showingFilters}
+				aria-label={`Filter by ${filter}. ${isEnabled ? 'Selected.' : ''}`}
+				aria-hidden={!state.showingAccessibility}
+				disabled={!state.showingAccessibility}
 				onClick={ filterOptionClickHandler }>
 				{ filter == 'Keyboard Accessible' ? <KeyboardIcon color='#000' /> : '' }
 				{ filter == 'Screen Reader Accessible' ? <ScreenReaderIcon color='#000' /> : '' }
@@ -255,10 +259,12 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 							<span className='label'>Filter by:</span>
 							<button
 								className={`filter-toggle desktop-only ${state.showingFilters ? 'close-mode' : ''}`}
+								aria-label={state.showingFilters ? 'Feature filters drawer open' : 'Filter catalog by features'}
 								onClick={ filterLinkClickHandler }>
 								Feature</button>
 							<button
 								className={`filter-toggle desktop-only ${state.showingAccessibility ? 'close-mode' : ''}`}
+								aria-label={state.showingAccessibility ? 'Accessibility filters drawer open' : 'Filter catalog by accessibility'}
 								onClick={ accessibilityLinkClickHandler }>
 								Accessibility</button>
 							<div className={'search' + (state.searchText === '' ? '' : ' not-empty')}>
@@ -291,14 +297,14 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 					</div>
 					{ mobileFilterRender }
 					<div id='filters-container'
-						className={`ready ${state.showingFilters ? 'open' : 'closed'}`}>
-						<div className='filter-labels-container'>
+						className={`ready ${state.showingFilters ? 'open' : 'closed'}`} aria-hidden={!state.showingFilters}>
+						<div className='filter-labels-container' disabled={!state.showingFilters}>
 							{ filterOptionsRender }
 						</div>
 					</div>
 					<div id='filters-container'
-						className={`ready ${state.showingAccessibility ? 'open' : 'closed'}`}>
-						<div className='filter-labels-container accessibility'>
+						className={`ready ${state.showingAccessibility ? 'open' : 'closed'}`} aria-hidden={!state.showingAccessibility}>
+						<div className='filter-labels-container accessibility' disabled={!state.showingAccessibility}>
 							{ accessibilityOptionsRender }
 						</div>
 					</div>

--- a/src/components/catalog.jsx
+++ b/src/components/catalog.jsx
@@ -10,6 +10,7 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 	const [state, setState] = useState({
 		searchText: '',
 		showingFilters: false,
+		showingAccessibility: false,
 		activeFilters: [],
 		showMobileFilters: false
 	})
@@ -17,14 +18,18 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 
 	// collect all unique features and supported data
 	const filters = useMemo(() => {
-			const filters = new Set()
+			const features = new Set()
+			const accessibility = new Set()
 			widgets.forEach(w => {
-				w.meta_data.features.forEach(f => {filters.add(f)})
-				w.meta_data.supported_data.forEach(f => {filters.add(f)})
-				if(w.meta_data.hasOwnProperty('accessibility_keyboard')) filters.add('Keyboard Accessible')
-				if(w.meta_data.hasOwnProperty('accessibility_reader')) filters.add('Screen Reader Accessible')
+				w.meta_data.features.forEach(f => {features.add(f)})
+				w.meta_data.supported_data.forEach(f => {features.add(f)})
+				if(w.meta_data.hasOwnProperty('accessibility_keyboard')) accessibility.add('Keyboard Accessible')
+				if(w.meta_data.hasOwnProperty('accessibility_reader')) accessibility.add('Screen Reader Accessible')
 			})
-			return Array.from(filters)
+			return {
+				features: Array.from(features),
+				accessibility: Array.from(accessibility)
+			}
 		},
 		[widgets]
 	)
@@ -72,6 +77,15 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 		setState({...state, activeFilters: newFilters, showMobileFilters: false})
 	}
 
+	const accessibilityLinkClickHandler = () => {
+		if (state.showingAccessibility){
+			setState({...state, showingAccessibility: !state.showingAccessibility, activeFilters: []})
+		}
+		else {
+			setState({...state, showingAccessibility: !state.showingAccessibility})
+		}
+	}
+
 	const filterLinkClickHandler = () => {
 		if(state.showingFilters){
 			setState({...state, showingFilters: !state.showingFilters, activeFilters: []})
@@ -92,7 +106,7 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 
 	let mobileFilterRender = null
 	if (state.showMobileFilters) {
-		const mobileFilterOptionsRender = filters.map(filter => (
+		const mobileFilterOptionsRender = filters.features.map(filter => (
 			<label key={filter}>
 				<input type='checkbox'
 					className='filter-button'
@@ -114,7 +128,19 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 		)
 	}
 
-	const filterOptionsRender = filters.map((filter, index) => {
+	const filterOptionsRender = filters.features.map((filter, index) => {
+		const isEnabled = state.activeFilters.includes(filter)
+		const filterOptionClickHandler = () => toggleFilter(filter)
+		return <button key={index}
+				className={'feature-button' + (isEnabled ? ' selected' : '')}
+				aria-hidden={!state.showingFilters}
+				onClick={ filterOptionClickHandler }>
+				{filter}
+			</button>
+		}
+	)
+
+	const accessibilityOptionsRender = filters.accessibility.map((filter, index) => {
 		const isEnabled = state.activeFilters.includes(filter)
 		const filterOptionClickHandler = () => toggleFilter(filter)
 		return <button key={index}
@@ -203,22 +229,29 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 
 					<div className='top'>
 						<h1>Widget Catalog</h1>
-						<button
-							className='filter-toggle cancel_button desktop-only'
-							onClick={ filterLinkClickHandler }>
-								{state.showingFilters ? 'Clear Filters' : 'Filter by feature'}
-						</button>
-						<div className={'search' + (state.searchText === '' ? '' : ' not-empty')}>
-							<input value={state.searchText} onChange={(e) => {setState({...state, searchText: e.target.value})}} type='text'/>
-							<div className='search-icon'>
-								<svg viewBox='0 0 250.313 250.313'>
-									<path d='m244.19 214.6l-54.379-54.378c-0.289-0.289-0.628-0.491-0.93-0.76 10.7-16.231 16.945-35.66 16.945-56.554 0-56.837-46.075-102.91-102.91-102.91s-102.91 46.075-102.91 102.91c0 56.835 46.074 102.91 102.91 102.91 20.895 0 40.323-6.245 56.554-16.945 0.269 0.301 0.47 0.64 0.759 0.929l54.38 54.38c8.169 8.168 21.413 8.168 29.583 0 8.168-8.169 8.168-21.413 0-29.582zm-141.28-44.458c-37.134 0-67.236-30.102-67.236-67.235 0-37.134 30.103-67.236 67.236-67.236 37.132 0 67.235 30.103 67.235 67.236s-30.103 67.235-67.235 67.235z'
-										clipRule='evenodd'
-										fillRule='evenodd'/>
-								</svg>
+						<aside>
+							<span className='label'>Filter by:</span>
+							<button
+								className={`filter-toggle desktop-only ${state.showingFilters ? 'close-mode' : ''}`}
+								onClick={ filterLinkClickHandler }>
+								Feature</button>
+							<button
+								className={`filter-toggle desktop-only ${state.showingAccessibility ? 'close-mode' : ''}`}
+								onClick={ accessibilityLinkClickHandler }>
+								Accessibility</button>
+							<div className={'search' + (state.searchText === '' ? '' : ' not-empty')}>
+								<input value={state.searchText} onChange={(e) => {setState({...state, searchText: e.target.value})}} type='text'/>
+								<div className='search-icon'>
+									<svg viewBox='0 0 250.313 250.313'>
+										<path d='m244.19 214.6l-54.379-54.378c-0.289-0.289-0.628-0.491-0.93-0.76 10.7-16.231 16.945-35.66 16.945-56.554 0-56.837-46.075-102.91-102.91-102.91s-102.91 46.075-102.91 102.91c0 56.835 46.074 102.91 102.91 102.91 20.895 0 40.323-6.245 56.554-16.945 0.269 0.301 0.47 0.64 0.759 0.929l54.38 54.38c8.169 8.168 21.413 8.168 29.583 0 8.168-8.169 8.168-21.413 0-29.582zm-141.28-44.458c-37.134 0-67.236-30.102-67.236-67.235 0-37.134 30.103-67.236 67.236-67.236 37.132 0 67.235 30.103 67.235 67.236s-30.103 67.235-67.235 67.235z'
+											clipRule='evenodd'
+											fillRule='evenodd'/>
+									</svg>
+								</div>
+								{ searchCloseRender }
 							</div>
-							{ searchCloseRender }
-						</div>
+						</aside>
+						
 					</div>
 
 					<div aria-hidden={!isMobileDevice()} id='active-filters' className='mobile-only'>
@@ -235,6 +268,12 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 						className={`ready ${state.showingFilters ? 'open' : 'closed'}`}>
 						<div className='filter-labels-container'>
 							{ filterOptionsRender }
+						</div>
+					</div>
+					<div id='filters-container'
+						className={`ready ${state.showingAccessibility ? 'open' : 'closed'}`}>
+						<div className='filter-labels-container accessibility'>
+							{ accessibilityOptionsRender }
 						</div>
 					</div>
 

--- a/src/components/catalog.jsx
+++ b/src/components/catalog.jsx
@@ -12,7 +12,8 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 		showingFilters: false,
 		showingAccessibility: false,
 		activeFilters: [],
-		showMobileFilters: false
+		showMobileFilters: false,
+		showMobileAccessibilityFilters: false
 	})
 	const totalWidgets = widgets.length
 
@@ -122,6 +123,27 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 			<div
 				id='filter-dropdown'
 				className='mobile-only'
+				aria-hidden={!isMobileDevice()}>
+				{ mobileFilterOptionsRender }
+			</div>
+		)
+	} else if (state.showMobileAccessibilityFilters) {
+		const mobileFilterOptionsRender = filters.accessibility.map(filter => (
+			<label key={filter}>
+				<input type='checkbox'
+					className='filter-button'
+					checked={state.activeFilters.includes(filter)}
+					readOnly={true}
+					onClick={ () => toggleFilter(filter) }
+				/>
+				{filter}
+			</label>
+		))
+
+		mobileFilterRender = (
+			<div
+				id='filter-dropdown'
+				className='mobile-only accessibility'
 				aria-hidden={!isMobileDevice()}>
 				{ mobileFilterOptionsRender }
 			</div>
@@ -254,12 +276,16 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 						
 					</div>
 
-					<div aria-hidden={!isMobileDevice()} id='active-filters' className='mobile-only'>
-						<button id='add-filter'
-							onClick={ () =>  { setState({...state, showMobileFilters: !state.showMobileFilters}) } }>
+					<div aria-hidden={!isMobileDevice()} className='mobile-filter-select mobile-only'>
+						<button className='add-filter'
+							onClick={ () =>  { setState({...state, showMobileFilters: !state.showMobileFilters, showMobileAccessibilityFilters: false}) } }>
 							{state.activeFilters.length ? 'Filters' : 'Filter by Feature'}
 						</button>
-						<div>
+						<button className='add-filter'
+							onClick={ () =>  { setState({...state, showMobileAccessibilityFilters: !state.showMobileAccessibilityFilters, showMobileFilters: false}) } }>
+							{state.activeFilters.length ? 'Accessibility' : 'Filter by Accessibility'}
+						</button>
+						<div className='active-filters'>
 							{ state.activeFilters.join(', ') }
 						</div>
 					</div>

--- a/src/components/catalog.scss
+++ b/src/components/catalog.scss
@@ -328,6 +328,10 @@
 					text-decoration: none;
 				}
 
+				&:focus {
+					background-color: #e2f3ff;
+				}
+
 				.header {
 					float: left;
 					// margin-top: -4px;

--- a/src/components/catalog.scss
+++ b/src/components/catalog.scss
@@ -488,7 +488,7 @@
 			margin: auto 0;
 
 			.filter-labels-container {
-				margin: 10px 5px;
+				margin: 20px 10px 0px 10px;
 			}
 		}
 
@@ -556,6 +556,7 @@
 
 		section.page {
 			overflow: visible;
+			min-width: 320px;
 		}
 
 		.top {
@@ -579,18 +580,22 @@
 			}
 		}
 
-		#active-filters {
+		.mobile-filter-select {
 			background: #eee;
 			font-size: 13px;
-			padding: 6px 10px 6px 70px;
+			padding: 6px 10px;
 			position: relative;
 			min-height: 18px;
 		}
 
-		#add-filter {
-			position: absolute;
-			left: 10px;
-			top: calc(50% - 10px);
+		.active-filters {
+			width: calc(100% - 20px);
+			padding: 6px 10px;
+			font-size: 13px;
+			background: #eee;
+		}
+
+		.add-filter {
 			padding: 2px 7px;
 			border: none;
 			color: #3690e6;
@@ -622,6 +627,10 @@
 			z-index: 3;
 			left: 10px;
 			top: 67px;
+
+			&.accessibility {
+				left: 124px;
+			}
 
 			label {
 				display: block;

--- a/src/components/catalog.scss
+++ b/src/components/catalog.scss
@@ -22,11 +22,17 @@
 	}
 
 	.top {
-		background: #eee;
-		color: #333;
-		padding: 10px 15px;
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+
 		position: relative;
 		z-index: 2;
+
+		padding: 10px 15px;
+		background: #eee;
+		color: #333;
+
 		font-weight: bold;
 
 		h1 {
@@ -34,82 +40,104 @@
 			display: inline-block;
 		}
 
-		.filter-toggle {
-			display: inline-block;
-			position: absolute;
-			right: 212px;
-			top: 5px;
-			font-size: 0.8em;
-			margin: 10px 15px;
-		}
+		aside {
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+			gap: 5px;
 
-		.search {
-			position: absolute;
-			width: 215px;
-			max-width: 42%;
-			right: 10px;
-			top: 10px;
+			button.filter-toggle {
+				display: inline-block;
+				margin: 0 4px;
+				padding: 1px 0;
 
-			.search-icon {
-				position: absolute;
-				top: 6px;
-				left: 9px;
-				height: 16px;
-				width: 20px;
-				// fill: #898686;
-				svg {
-					height: 100%;
-					width: 100%;
-				}
-			}
-
-			.search-close {
-				cursor: pointer;
-				position: absolute;
-				border: none;
 				background: none;
-				width: 16px;
-				height: 16px;
-				top: 8px;
-				right: 15px;
-				opacity: 0.8;
+				border: 0;
+				border-bottom: solid 1px #3690e6;
+				color: #3690e6;
+				font-size: 0.8em;
+				
+				cursor: pointer;
+				// text-decoration: underline;
+	
+				&.close-mode:after {
+					position: relative;
+					bottom: -1px;
+					content: 'X';
+					margin-left: 3px;
 
-				&:hover {
-					opacity: 1;
-				}
-
-				&:before,
-				&:after {
-					position: absolute;
-					left: 8px;
-					top: 0;
-					content: ' ';
-					height: 14px;
-					width: 2px;
-					background-color: white;
-					transform: rotate(45deg);
-				}
-
-				&:after {
-					transform: rotate(-45deg);
+					color: #000;
+					font-weight: bold;
+					border: 0;
 				}
 			}
 
-			input {
-				position: absolute;
-				box-sizing: border-box;
-				border: none;
-				width: 100%;
-				right: 0;
-				padding: 4px 35px 4px 35px;
-				font-size: 14px;
-				background: #fff;
-				border: solid 1px #b0b0b0;
-				border-radius: 12px;
-				margin: 0;
-
-				&::-ms-clear {
-					display: none;
+			.search {
+				position: relative;
+				width: 215px;
+				margin-left: 10px;
+				// max-width: 42%;
+	
+				.search-icon {
+					position: absolute;
+					top: 6px;
+					left: 9px;
+					height: 16px;
+					width: 20px;
+					// fill: #898686;
+					svg {
+						height: 100%;
+						width: 100%;
+					}
+				}
+	
+				.search-close {
+					cursor: pointer;
+					position: absolute;
+					border: none;
+					background: none;
+					width: 16px;
+					height: 16px;
+					top: 8px;
+					right: 15px;
+					opacity: 0.8;
+	
+					&:hover {
+						opacity: 1;
+					}
+	
+					&:before,
+					&:after {
+						position: absolute;
+						left: 8px;
+						top: 0;
+						content: ' ';
+						height: 14px;
+						width: 2px;
+						background-color: white;
+						transform: rotate(45deg);
+					}
+	
+					&:after {
+						transform: rotate(-45deg);
+					}
+				}
+	
+				input {
+					box-sizing: border-box;
+					border: none;
+					width: 100%;
+					right: 0;
+					padding: 4px 35px 4px 35px;
+					font-size: 14px;
+					background: #fff;
+					border: solid 1px #b0b0b0;
+					border-radius: 12px;
+					margin: 0;
+	
+					&::-ms-clear {
+						display: none;
+					}
 				}
 			}
 		}
@@ -150,7 +178,29 @@
 			display: flex;
 			justify-content: center;
 			flex-wrap: wrap;
-			margin: 10px;
+			margin: 20px 10px 0px 10px;
+
+			&:before {
+				content: 'Features';
+				position: absolute;
+				left: 50%;
+				top: 5px;
+
+				font-size: 12px;
+				font-style: italic;
+				color: #888;
+			}
+
+			&.accessibility:before {
+				content: 'Accessibility';
+				position: absolute;
+				left: 50%;
+				top: 5px;
+
+				font-size: 12px;
+				font-style: italic;
+				color: #888;
+			}
 
 			button {
 				padding: 10px 12px;
@@ -509,9 +559,16 @@
 		}
 
 		.top {
-			flex-direction: column;
+			flex-direction: row;
 			position: relative;
 			padding: 10px 15px 5px;
+
+			aside {
+				margin-top: 4px;
+				.label {
+					display: none;
+				}
+			}
 
 			.search {
 				margin: auto;

--- a/src/components/detail.jsx
+++ b/src/components/detail.jsx
@@ -21,33 +21,13 @@ const initWidgetData = () => ({
 	accessibility: {},
 })
 
-const getAccessibilityData = metadata => {
-	// The 'score' property of the object being returned is derived from both accessibility options' values.
-	// A score of 0 indicates that neither accessibility option was set.
-	const VALUE_SCORES = {
-		None: 1,
-		Limited: 2,
-		Full: 3
-	}
+const getAccessibilityData = (metadata) => {
 
-	let data = {
-		keyboard: 'Unavailable',
-		screen_reader: 'Unavailable',
-		score: 0,
+	return {
+		keyboard: metadata.accessibility_keyboard ? metadata.accessibility_keyboard : 'Unavailable',
+		screen_reader: metadata.accessibility_reader ? metadata.accessibility_reader : 'Unavailable',
+		description: metadata.accessibility_description ? metadata.accessibility_description : ''
 	}
-
-	// Checks if widgets don't have accessibility options
-	if (metadata.accessibility_keyboard) {
-		data.keyboard = metadata.accessibility_keyboard
-		data.score += VALUE_SCORES[metadata.accessibility_keyboard]
-	}
-
-	if (metadata.accessibility_reader) {
-		data.screen_reader = metadata.accessibility_reader
-		data.score += VALUE_SCORES[metadata.accessibility_reader]
-	}
-
-	return data
 }
 
 const _tooltipObject = (text) => ({
@@ -154,11 +134,10 @@ const Detail = ({widget, isFetching}) => {
 				<DetailFeatureList widgetData={widgetData} title='Supported Data' type='supported-data'/>
 			)
 		}
-		let accessibilityRender = null
-		if (widgetData.accessibility.score) {
-			accessibilityRender = (
-				<AccessibilityIndicator widget={widgetData}/>
-			)
+
+		let accessibilityRender = null 
+		if(!widgetData.dataLoading) {
+			accessibilityRender = <AccessibilityIndicator widget={widgetData} />
 		}
 
 		let createRender = null

--- a/src/components/detail.scss
+++ b/src/components/detail.scss
@@ -63,6 +63,28 @@ $color-green: #c5dd60;
 						margin-bottom: 10px;
 					}
 
+					&.accessibility-indicator {
+						display: none;
+
+						&.show {
+							display: block;
+						}
+					}
+
+					&.accessibility-description {
+						display: none;
+						margin: 10px 0 0 0;
+
+						font-size: 14px;
+						font-weight: 300;
+						font-style: italic;
+						color: #5a5a5a;
+
+						&.show {
+							display: block;
+						}
+					}
+
 					.icon-spacer {
 						display: inline-block;
 						width: 35px;


### PR DESCRIPTION
- Splits widget catalog filter options into Features and Accessibility. The options can be displayed separately or in combination, and the filters are applied in aggregate.
- Update accessibility UI elements in widget detail pages.
- Adds an additional `accessibility_description` `meta_data` field to provide additional context about a widget's accessibility status. The indicators are no longer displayed if a widget does not provide accessibility information; the description will simply note that accessibility data is not available.