### PR TITLE
Fixes refresh in LTI picker and widget player iframe scrolling

### DIFF
--- a/src/components/hooks/useInstanceList.jsx
+++ b/src/components/hooks/useInstanceList.jsx
@@ -35,6 +35,7 @@ export default function useInstanceList() {
 		isFetching,
 		isFetchingNextPage,
 		status,
+		refetch
 	} = useInfiniteQuery({
 		queryKey: ['widgets'],
 		queryFn: getWidgetInstances,
@@ -48,7 +49,7 @@ export default function useInstanceList() {
 
 	// memoize the instance list since this is a large, expensive query
 	const instances = useMemo(() => formatData(data), [data])
-	
+
 	useEffect(() => {
 		if (hasNextPage) fetchNextPage()
 	},[instances])
@@ -56,6 +57,7 @@ export default function useInstanceList() {
 	return {
 		instances: instances,
 		isFetching: isFetching || hasNextPage,
+		refresh: () => refetch(),
 		...(errorState == true ? {error: true} : {}) // the error value is only provided if errorState is true
 	}
 }

--- a/src/components/lti/select-item.jsx
+++ b/src/components/lti/select-item.jsx
@@ -41,7 +41,7 @@ const SelectItem = () => {
 	}
 
 	const refreshListing = () => {
-		refetchInstances()
+		instanceList.refresh()
 		setShowRefreshArrow(false)
 	}
 

--- a/src/components/my-widgets-embed.jsx
+++ b/src/components/my-widgets-embed.jsx
@@ -3,8 +3,10 @@ import React, { useState } from 'react'
 const getEmbedLink = (inst, autoplayToggle = true) => {
 	if (inst === null) return ''
 
+	let footerHeight = 38
+
 	const width = String(inst.widget.width) !== '0' ? inst.widget.width : 800
-	const height = String(inst.widget.height) !== '0' ? inst.widget.height : 600
+	const height = String(inst.widget.height) !== '0' ? inst.widget.height + footerHeight : 600
 
 	// This is kind of nasty, but cleaner alternatives are not currently worth the effort.
 	return `<iframe src='${inst.embed_url}?autoplay=${autoplayToggle?'true':'false'}' width='${width}' height='${height}' style='margin:0;padding:0;border:0;'></iframe>`

--- a/src/components/widget-player.scss
+++ b/src/components/widget-player.scss
@@ -41,19 +41,19 @@ section.widget {
 			content: 'Previewing';
 			background: #b944cc;
 			display: block;
-		
+
 			left: 0px;
 			top: -40px;
 			width: 160px;
 			height: 20px;
 			padding: 8px 0 12px 0;
-		
+
 			font-size: 20px;
 			font-weight: 900;
 			color: #ffffff;
 			text-align: center;
 			vertical-align: middle;
-		
+
 			border-radius: 5px 5px 0 0;
 		}
 
@@ -61,29 +61,28 @@ section.widget {
 			content: 'Scores and interactions will not be recorded while previewing.';
 			position: absolute;
 			display: block;
-		
+
 			right: 0px;
 			top: 16px;
-		
+
 			font-size: 14px;
 			font-weight: 300;
 		}
 	}
 
 	.center {
-		margin: 0 auto 38px;
 		background: white;
 		height: 100%;
 		min-height: 400px;
-	
+
 		#container {
 			margin: 0 auto;
 			outline: 1px solid #999;
 			display: block;
-		
+
 			font-family: 'Lato', arial, sans-serif;
 		}
-		
+
 		#container.html {
 			border: 0;
 			height: 100%;
@@ -92,24 +91,22 @@ section.widget {
 	}
 
 	section.player-footer {
-		position: relative;
-		height: 20px;
-
-		top: -38px;
+		height: 38px;
 
 		margin: 0 auto;
-		padding: 4px 0;
+		padding: 4px 10px;
 
 		border-top: solid 2px $color-purple;
 		border-bottom-right-radius: 5px;
 		border-bottom-left-radius: 5px;
+		box-sizing: border-box;
 
 		background: #ebebeb;
 
+		display: flex;
+		justify-content: space-between;
+
 		a {
-			position: absolute;
-			top: 0px;
-			right: 15px;
 			display: block;
 
 			padding-top: 4px;
@@ -121,7 +118,6 @@ section.widget {
 			text-decoration: underline;
 
 			&.materia-logo {
-				left: 10px;
 				width: 100px;
 
 				img {


### PR DESCRIPTION
Refetches query in ``useInstanceList`` on manual refresh in the LTI picker

Adds footer height to the embedded iframe's height and updates footer styling so the scrollbar is removed in embedded widgets