### PR TITLE
React branch media importer updates

### DIFF
--- a/fuel/app/classes/materia/widget/asset.php
+++ b/fuel/app/classes/materia/widget/asset.php
@@ -20,6 +20,7 @@ class Widget_Asset
 		'image/gif'   => 'gif',
 		'image/jpeg'  => 'jpg',
 		'audio/mp4'   => 'm4a',
+		'audio/x-m4a' => 'm4a',
 		'audio/mpeg'  => 'mp3',
 		'audio/wav'   => 'wav',
 		'audio/wave'  => 'wav',

--- a/fuel/app/classes/materia/widget/asset.php
+++ b/fuel/app/classes/materia/widget/asset.php
@@ -16,11 +16,15 @@ class Widget_Asset
 	const MAP_TYPE_QUESTION = '2';
 
 	protected const MIME_TYPE_TO_EXTENSION = [
-		'image/png' => 'png',
-		'image/gif' => 'gif',
-		'image/jpeg' => 'jpg',
-		'audio/mpeg' => 'mp3',
-		'text/plain' => 'obj',
+		'image/png'   => 'png',
+		'image/gif'   => 'gif',
+		'image/jpeg'  => 'jpg',
+		'audio/mp4'   => 'm4a',
+		'audio/mpeg'  => 'mp3',
+		'audio/wav'   => 'wav',
+		'audio/wave'  => 'wav',
+		'audio/x-wav' => 'wav',
+		'text/plain'  => 'obj',
 	];
 
 	protected const MIME_TYPE_FROM_EXTENSION = [
@@ -28,8 +32,10 @@ class Widget_Asset
 		'gif'  => 'image/gif',
 		'jpg'  => 'image/jpeg',
 		'jpeg' => 'image/jpeg',
+		'm4a'  => 'audio/mp4',
 		'mp3'  => 'audio/mpeg',
-		'obj' => 'text/plain',
+		'wav'  => 'audio/wav',
+		'obj'  => 'text/plain',
 	];
 
 	public $created_at = 0;

--- a/fuel/app/config/file.php
+++ b/fuel/app/config/file.php
@@ -14,10 +14,9 @@ return array(
 	'areas' => [
 		'media' => [
 			'basedir'    => realpath(APPPATH.'media').DS,
-			'extensions' => ['jpg', 'jpeg', 'png', 'gif', 'wav', 'mp3', 'obj'],
+			'extensions' => ['jpg', 'jpeg', 'png', 'gif', 'wav', 'mp3', 'obj', 'm4a'],
 			'url'        => DOCROOT . 'media',
 		]
 	],
 
 );
-

--- a/src/components/media-importer.jsx
+++ b/src/components/media-importer.jsx
@@ -17,7 +17,7 @@ const FILE_MAX_SIZE = 20000000
 const MIME_MAP = {
 	// generic types, preferred
 	image: ['image/jpg', 'image/jpeg', 'image/gif', 'image/png'],
-	audio: ['audio/mp3', 'audio/mpeg', 'audio/mpeg3', 'audio/mp4', 'audio/x-m4a', 'audio/wave', 'audio/wav', 'audio/x-wav'],
+	audio: ['audio/mp3', 'audio/mpeg', 'audio/mpeg3', 'audio/mp4', 'audio/x-m4a', 'audio/wave', 'audio/wav', 'audio/x-wav', 'audio/m4a'],
 	video: [], // placeholder
 	model: ['model/obj'],
 
@@ -27,7 +27,7 @@ const MIME_MAP = {
 	gif: ['image/gif'],
 	png: ['image/png'],
 	mp3: ['audio/mp3', 'audio/mpeg', 'audio/mpeg3'],
-	m4a: ['audio/mp4', 'audio/x-m4a'],
+	m4a: ['audio/mp4', 'audio/x-m4a', 'audio/m4a'],
 	wav: ['audio/wave', 'audio/wav', 'audio/x-wav'],
 	obj: ['application/octet-stream', 'model/obj'],
 }
@@ -72,7 +72,6 @@ const MediaImporter = () => {
 			if (!data || data.type == 'error') console.error(`Asset request failed with error: ${data.msg}`)
 			else {
 				const list = data.map(asset => {
-	
 					const creationDate = new Date(asset.created_at * 1000)
 					return {
 						id: asset.id,
@@ -102,13 +101,13 @@ const MediaImporter = () => {
 		if (!assetList || !assetList.length) return
 
 		const allowed = _getAllowedFileTypes().map((type) => type.split('/')[1])
-		
+
 		// first pass: filter out by allowed media types as well as deleted assets, if we're not displaying them
 		let listStageOne = assetList.filter((asset) => ((!showDeletedAssets && !asset.is_deleted) || showDeletedAssets) && allowed.indexOf(asset.type) != -1)
 
 		// second pass: filter assets based on search string, if present
 		let listStageTwo = filterSearch.length ? listStageOne.filter((asset) => asset.name.toLowerCase().match( filterSearch.toLowerCase() )) : listStageOne
-		
+
 		// third and final pass: sort assets based on the currently selected sort method and direction
 		let listStageThree = sortState.sortAsc ?
 			listStageTwo.sort(SORT_OPTIONS[sortState.sortOrder].sortMethod) :
@@ -139,7 +138,7 @@ const MediaImporter = () => {
 			case 'png': // intentional case fall-through
 			case 'gif': // intentional case fall-through
 				return `${MEDIA_URL}/${data}/thumbnail`
-	
+
 			case 'mp3': // intentional case fall-through
 			case 'wav': // intentional case fall-through
 			case 'm4a': // intentional case fall-through
@@ -203,7 +202,7 @@ const MediaImporter = () => {
 			if (e.lengthComputable) {
 				const progress = Math.round((e.loaded / e.total) * 100);
 				setAssetLoadingProgress(progress);
-			  }
+			}
 		})
 
 		request.onreadystatechange = () => {
@@ -218,7 +217,7 @@ const MediaImporter = () => {
 				}
 			}
 		}
-		
+
 		request.open('POST', MEDIA_UPLOAD_URL, true)
 		request.send(fd)
 	}

--- a/src/components/media-importer.jsx
+++ b/src/components/media-importer.jsx
@@ -17,7 +17,7 @@ const FILE_MAX_SIZE = 20000000
 const MIME_MAP = {
 	// generic types, preferred
 	image: ['image/jpg', 'image/jpeg', 'image/gif', 'image/png'],
-	audio: ['audio/mp3', 'audio/mpeg', 'audio/mpeg3', 'audio/mp4', 'audio/wave', 'audio/wav', 'audio/x-wav'],
+	audio: ['audio/mp3', 'audio/mpeg', 'audio/mpeg3', 'audio/mp4', 'audio/x-m4a', 'audio/wave', 'audio/wav', 'audio/x-wav'],
 	video: [], // placeholder
 	model: ['model/obj'],
 
@@ -27,7 +27,7 @@ const MIME_MAP = {
 	gif: ['image/gif'],
 	png: ['image/png'],
 	mp3: ['audio/mp3', 'audio/mpeg', 'audio/mpeg3'],
-	m4a: ['audio/mp4'],
+	m4a: ['audio/mp4', 'audio/x-m4a'],
 	wav: ['audio/wave', 'audio/wav', 'audio/x-wav'],
 	obj: ['application/octet-stream', 'model/obj'],
 }

--- a/src/components/media-importer.jsx
+++ b/src/components/media-importer.jsx
@@ -142,7 +142,7 @@ const MediaImporter = () => {
 	
 			case 'mp3': // intentional case fall-through
 			case 'wav': // intentional case fall-through
-			case 'ogg': // intentional case fall-through
+			case 'm4a': // intentional case fall-through
 				return '/img/audio.png'
 		}
 	}

--- a/src/components/media.scss
+++ b/src/components/media.scss
@@ -230,7 +230,7 @@ body.import {
 	width: calc(100% - 20px);
 	max-width: calc(100% - 20px);
 	height: 100%;
-	overflow-y: scroll;
+	overflow-y: auto;
 	margin-top: 10px;
 
 	.file-info {

--- a/src/components/media.scss
+++ b/src/components/media.scss
@@ -18,9 +18,10 @@ body.import {
 	width: 800px;
 
 	> section {
-		height: 100vh;
+		position: relative;
+		height: calc(100vh - 35px);
 		width: 45%;
-		padding: 0 2.5%;
+		padding: 0 2.5% 35px 2.5%;
 
 		&:first-child {
 			&:before {
@@ -47,6 +48,28 @@ body.import {
 			width: 47%;
 			flex-flow: column;
 			padding: 0 0.5% 0 2.5%;
+		}
+
+		.loading-icon-holder {
+			z-index: 100;
+			position: absolute;
+			top: calc(50vh - 100px);
+			left: 50%;
+			display: flex;
+			flex-direction: column-reverse;
+			width: 180px;
+			height: 200px;
+			margin-left: -90px;
+	
+			background: rgba(255,255,255,0.95);
+			border-radius: 10px;
+
+			.progress {
+				display: block;
+				padding-bottom: 10px;
+				text-align: center;
+				font-weight: bold;
+			}
 		}
 	}
 
@@ -83,6 +106,25 @@ body.import {
 	.select_file_button {
 		margin: 5px 0px;
 		font-weight: 400;
+	}
+
+	.pane-footer {
+		position: absolute;
+		width: 100%;
+		bottom: 0px;
+
+		span.content {
+			display: inline-block;
+			padding: 6px 2.5%;
+			background: rgba(255,255,255,0.95);
+
+			font-size: 14px;
+
+			&.error-state {
+				font-weight: bold;
+				color: #730000;
+			}
+		}
 	}
 }
 

--- a/src/components/widget-creator-page.scss
+++ b/src/components/widget-creator-page.scss
@@ -259,7 +259,7 @@ a {
 	left: 50%;
 	margin: -250px -387px;
 	width: 675px;
-	height: 500px;
+	height: 535px;
 	z-index: 2;
 	box-shadow: 0px 0px 1000px #000, 0px 0px 10px #000;
 	opacity: 0;

--- a/src/media.js
+++ b/src/media.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { QueryClient, QueryClientProvider, QueryCache } from 'react-query'
-import { ReactQueryDevtools } from 'react-query/devtools'
 import MediaImporter from './components/media-importer'
 
 const queryCache = new QueryCache()
@@ -10,5 +9,4 @@ export const queryClient = new QueryClient({ queryCache })
 ReactDOM.render(
 	<QueryClientProvider client={queryClient} contextSharing={true}>
 		<MediaImporter />
-		<ReactQueryDevtools initialIsOpen={false} />
 	</QueryClientProvider>, document.getElementById('app'))


### PR DESCRIPTION
- Fixed previously imported media assets not being filtered in the importer based on allowed file types requested by the widget
- Added support for .wav and .m4a audio formats
- Rebuilt file upload logic to be faster and more performant by removing dependency on `FileReader` conversion to a Data URI followed by a Blob.
- Added language indicating allowed media type(s)
- Added additional error states
- Added upload progress indicator