### PR TITLE
Add expected `img` property to widget instance objects used by the LTI widget picker.

### DIFF
--- a/fuel/app/modules/lti/classes/ltilaunch.php
+++ b/fuel/app/modules/lti/classes/ltilaunch.php
@@ -36,7 +36,7 @@ class LtiLaunch
 			'last'           => Utils::safeTrim(\Input::param('lis_person_name_family', '')),
 			'first'          => Utils::safeTrim(\Input::param('lis_person_name_given', '')),
 			'fullname'       => Utils::safeTrim(\Input::param('lis_person_name_full', '')),
-			'outcome_ext'    => Utils::safeTrim(\Input::param('ext_outcome_data_values_accepted'), ''),
+			'outcome_ext'    => Utils::safeTrim(\Input::param('ext_outcome_data_values_accepted', '')),
 			'roles'          => $roles,
 			'remote_id'      => Utils::safeTrim(\Input::param($remote_id_field)),
 			'username'       => Utils::safeTrim(\Input::param($remote_user_field)),

--- a/src/components/hooks/useInstanceList.jsx
+++ b/src/components/hooks/useInstanceList.jsx
@@ -27,7 +27,7 @@ export default function useInstanceList() {
 						//  compatibility with any downstream LTIs using the widget picker
 						return {
 							...instance,
-							img: iconUrl(BASE_URL + 'widget/', instance.widget.dir, 60)
+							img: iconUrl(BASE_URL + 'widget/', instance.widget.dir, 275)
 						}
 					}))
 				)

--- a/src/components/hooks/useInstanceList.jsx
+++ b/src/components/hooks/useInstanceList.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useInfiniteQuery } from 'react-query'
 import { apiGetWidgetInstances } from '../../util/api'
+import { iconUrl } from '../../util/icon-url'
 
 export default function useInstanceList() {
 
@@ -19,7 +20,18 @@ export default function useInstanceList() {
 		}
 		if (list?.pages) {
 			let dataMap = []
-			return [...dataMap.concat(...list.pages.map((page) => page.pagination))].sort(_compareWidgets)
+			return [
+				...dataMap.concat(
+					...list.pages.map(page => page.pagination.map(instance => {
+						// adding an 'img' property to widget instance objects for backwards
+						//  compatibility with any downstream LTIs using the wid
+						return {
+							...instance,
+							img: iconUrl(BASE_URL + 'widget/', instance.widget.dir, 60)
+						}
+					}))
+				)
+			].sort(_compareWidgets)
 		} else return []
 	}
 

--- a/src/components/lti/select-item.jsx
+++ b/src/components/lti/select-item.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react'
 import useInstanceList from '../hooks/useInstanceList'
-import { iconUrl } from '../../util/icon-url'
 import LoadingIcon from '../loading-icon';
 
 const SelectItem = () => {
@@ -129,7 +128,7 @@ const SelectItem = () => {
 
 				return <li className={classList.join(' ')} key={index}>
 					<div className={`widget-info ${instance.is_draft ? 'draft' : ''} ${instance.guest_access ? 'guest' : ''}`}>
-						<img className="widget-icon" src={iconUrl(BASE_URL + 'widget/', instance.widget.dir, 60)}/>
+						<img className="widget-icon" src={instance.img}/>
 						<h2 className="searchable">{instance.name}</h2>
 						<h3 className="searchable">{instance.widget.name}</h3>
 						{instance.guest_access ? <h3 className="guest-notice">Guest instances cannot be embedded in courses. </h3> : <></>}

--- a/src/components/my-widgets-instance-card.jsx
+++ b/src/components/my-widgets-instance-card.jsx
@@ -1,9 +1,8 @@
 import React from 'react'
-import { iconUrl } from '../util/icon-url'
 import createHighlightSpan from '../util/create-highlight-span'
 
 const MyWidgetsInstanceCard = ({inst, indexVal, hidden = false, selected = false, onClick = () => {}, beard = null, searchText = null}) => {
-	const {id, widget, name, is_draft} = inst
+	const {id, widget, name, is_draft, img} = inst
 	// Handle multiple conditional classes by keeping an array of all classes to apply, then imploding it in the render
 	const classes = ['my-widgets-instance-card', 'widget']
 	if (hidden) classes.push('hidden')
@@ -27,7 +26,7 @@ const MyWidgetsInstanceCard = ({inst, indexVal, hidden = false, selected = false
 		<div id={`widget_${id}`}
 			className={classes.join(' ')}
 			onClick={clickHandler}>
-			<img className='icon' src={iconUrl('/widget/', widget.dir, 275)} />
+			<img className='icon' src={img} />
 			<ul>
 				<li className='title searchable'
 					dangerouslySetInnerHTML={{ __html: nameTextRender }}>

--- a/src/css/lti.scss
+++ b/src/css/lti.scss
@@ -408,6 +408,7 @@ html {
 
 				img {
 					float: left;
+					width: 100px;
 				}
 			}
 


### PR DESCRIPTION
Removes `iconUrl` use from widget picker, using it instead in the `useInstanceList` hook to add the `img` property to all widget instance objects for continued compatibility with any LTIs expecting that property such as Obojobo.

Fixes the assignment of the `outcome_ext` key in the LTI launch variable parsing code where it was erroneously defaulting to `null` instead of an empty string in the event that `ext_outcome_data_values_accepted` is not provided by incoming LTI params.