### PR TITLE
Fixes duplicate API score calls

### DIFF
--- a/src/components/score-overview.jsx
+++ b/src/components/score-overview.jsx
@@ -32,7 +32,7 @@ const ScoreOverview = ({inst_id, single_id, overview, attemptNum, isPreview, gue
 				}
 			</div>
 		)
-	} 
+	}
 
 	let overviewTable = []
 	overview.table.forEach((row, index) => {
@@ -88,7 +88,7 @@ const ScoreOverview = ({inst_id, single_id, overview, attemptNum, isPreview, gue
 			</>
 		)
 	}
-	
+
 	return (
 		<>
 			<section className={`overview ${isPreview ? 'preview' : ''}${!overview.complete ? 'incomplete' : ''}`}>

--- a/src/components/score-page.jsx
+++ b/src/components/score-page.jsx
@@ -48,7 +48,8 @@ const ScorePage = () => {
 	// Used to wait for window data to load
 	const waitForWindow = async () => {
 		while(!window.hasOwnProperty('IS_EMBEDDED')
-		&& !window.hasOwnProperty('IS_PREVIEW') && !window.hasOwnProperty('LAUNCH_TOKEN')) {
+		&& !window.hasOwnProperty('IS_PREVIEW')
+		&& !window.hasOwnProperty('LAUNCH_TOKEN')) {
 			await new Promise(resolve => setTimeout(resolve, 500))
 		}
 	}
@@ -59,15 +60,20 @@ const ScorePage = () => {
 		headerRender = <Header/>
 	}
 
+	let bodyRender = null
+	if ( state.isPreview !== undefined ) {
+		bodyRender = <Scores inst_id={state.instanceID}
+		play_id={state.playID}
+		single_id={state.singleID}
+		send_token={state.sendToken}
+		isEmbedded={state.isEmbedded}
+		isPreview={state.isPreview}/>
+	}
+
 	return (
 		<>
 			{ headerRender }
-			<Scores inst_id={state.instanceID}
-				play_id={state.playID}
-				single_id={state.singleID}
-				send_token={state.sendToken}
-				isEmbedded={state.isEmbedded}
-				isPreview={state.isPreview}/>
+			{ bodyRender }
 		</>
 	)
 }

--- a/src/components/scores.jsx
+++ b/src/components/scores.jsx
@@ -159,29 +159,36 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 		instance,
 	])
 
-	// Initializes the custom score screen
 	useEffect(() => {
+		// Fetch score data based on instance access
 		if (instance) {
-			let enginePath
 			setGuestAccess(instance.guest_access)
-
 			// Preview? Set certain attributes that wouldn't be assigned otherwise
 			if (isPreview) {
 				setPreviewInstId(instance.id)
 				setPlayId(null)
 				setAttributes({ ...attributes, href: `/preview/${inst_id}/${instance.clean_name}`, hidePlayAgain: false })
-			} else if (single_id) {
+			}
+			// Single play session
+			else if (single_id) {
 				setPlayId(single_id)
 				setPreviewInstId(null)
 			}
+			// Guest play session
 			else if (instance.guest_access) {
 				setAttributes({ ...attributes, href: `/${isEmbedded ? 'embed' : 'play'}/${inst_id}/${instance.clean_name}`, hidePlayAgain: false })
 				loadGuestScores()
 			}
-			else if (!single_id && !isPreview) loadInstanceScores()
+			// User play session
+			else loadInstanceScores()
+		}
+	}, [instance])
 
+	// Initializes the custom score screen
+	useEffect(() => {
+		if (instance) {
+			let enginePath
 			const score_screen = instance.widget.score_screen
-
 			// custom score screen exists?
 			if (score_screen && scoreTable) {
 				const splitSpot = score_screen.lastIndexOf('.')
@@ -627,7 +634,6 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 
 	let overviewRender = null
 	if (!errorState && showScoresOverview && !!overview) {
-
 		if (customScoreScreen.show && !customScoreScreen.ready) {
 			overviewRender = (
 				<section className={`overview ${isPreview ? 'preview' : ''}`}>

--- a/src/components/scores.scss
+++ b/src/components/scores.scss
@@ -94,10 +94,10 @@ $preview-purple: #b944cc;
 			display: block;
 			margin: 20px 0 0 0;
 			padding: 10px;
-			
+
 			color: #000;
 			// box-shadow: 0 1px 3px 0 #777;
-	
+
 			h2 {
 				font-size: 24px;
 				font-weight: bold;
@@ -106,20 +106,20 @@ $preview-purple: #b944cc;
 
 				border-bottom: solid 1px $light-gray-bg;
 			}
-	
+
 			hr {
 				width: auto;
 				margin: 5px;
 				padding: 0;
 			}
-	
+
 			p {
 				font-size: 14px;
 				margin: 5px 0 0 0;
 			}
 		}
 	}
-	
+
 	#overview-score {
 		display: inline-block;
 		margin: 0 auto;
@@ -169,7 +169,7 @@ $preview-purple: #b944cc;
 		width: 330px;
 		min-height: 180px;
 		background-color: $light-gray-bg;
-		
+
 		padding-top: 5px;
 		border-bottom-right-radius: 5px;
 
@@ -218,7 +218,7 @@ article {
 		min-height: 50px;
 
 		margin: 0;
-		
+
 		background: $header-color;
 		border-top-left-radius: 5px;
 		border-top-right-radius: 5px;
@@ -238,7 +238,7 @@ article {
 
 				content: 'Previewing';
 				background: $preview-purple;
-				
+
 				font-size: 20px;
 				font-weight: 900;
 				color: #ffffff;
@@ -271,6 +271,12 @@ article {
 			overflow-wrap: break-word;
 			word-wrap: break-word; // have to include word-wrap since Edge/IE11 will not support overflow-wrap
 			margin-left: -10px;
+		}
+
+		nav {
+			/** Override include.scss **/
+			visibility: visible;
+			opacity: 1;
 		}
 
 		nav.play-again {
@@ -308,10 +314,10 @@ article {
 				font-size: 12px;
 				color: #000;
 				background: #fff;
-				
+
 				border-radius: 15px;
-				
-				
+
+
 			}
 
 			&.open {
@@ -544,13 +550,13 @@ section.score-graph {
 	.graph {
 		width: 746px;
 		height: 320px;
-		
+
 		margin: 15px auto 0 auto;
 		padding: 20px 16px 0 16px;
-	
+
 		background: #fff;
 		box-shadow: inset 0px 1px 2px #333;
-	
+
 		.jqplot-yaxis-label {
 			padding-left: 5px;
 		}


### PR DESCRIPTION
Scorescreen is making two `widget_instance_play_scores_get` calls, one for when the `instance` loaded and one when `scoreTable` loaded. Moved play score data triggers to their own useEffect, separate from loading the custom score screen.

Adds a state check in the score page's lobby to ensure all global variables are loaded and set to state before entering the score page, such as `isPreview`

Overrides `include.css` styling that hides `nav` elements on page widths < 720px for embedded score screens

