### PR TITLE
Issue/1502

### DIFF
--- a/fuel/app/classes/materia/api/v1.php
+++ b/fuel/app/classes/materia/api/v1.php
@@ -1058,7 +1058,9 @@ class Api_V1
 				if ($is_enabled && Perm_Manager::is_student($new_perms->user_id))
 				{
 					// guest mode isn't enabled - don't give this student access
-					if ( ! $inst->allows_guest_players()) continue;
+					if ( ! $inst->allows_guest_players()) {
+						return Msg::student_collab();
+					}
 					Perm_Manager::set_user_game_asset_perms($item_id, $new_perms->user_id, [Perm::VISIBLE => $is_enabled], $new_perms->expiration);
 				}
 			}

--- a/fuel/app/classes/materia/api/v1.php
+++ b/fuel/app/classes/materia/api/v1.php
@@ -1060,7 +1060,8 @@ class Api_V1
 					// guest mode isn't enabled - don't give this student access
 					if ( ! $inst->allows_guest_players())
 					{
-						return Msg::student_collab();
+						$refused[] = $new_perms->user_id;
+						continue;
 					}
 					Perm_Manager::set_user_game_asset_perms($item_id, $new_perms->user_id, [Perm::VISIBLE => $is_enabled], $new_perms->expiration);
 				}
@@ -1079,6 +1080,11 @@ class Api_V1
 			}
 
 			\Model_Notification::send_item_notification($cur_user_id, $new_perms->user_id, $item_type, $item_id, $notification_mode, $new_perm);
+		}
+
+		if (count($refused) > 0)
+		{
+			return Msg::student_collab();
 		}
 
 		return true;

--- a/fuel/app/classes/materia/api/v1.php
+++ b/fuel/app/classes/materia/api/v1.php
@@ -1058,7 +1058,8 @@ class Api_V1
 				if ($is_enabled && Perm_Manager::is_student($new_perms->user_id))
 				{
 					// guest mode isn't enabled - don't give this student access
-					if ( ! $inst->allows_guest_players()) {
+					if ( ! $inst->allows_guest_players())
+					{
 						return Msg::student_collab();
 					}
 					Perm_Manager::set_user_game_asset_perms($item_id, $new_perms->user_id, [Perm::VISIBLE => $is_enabled], $new_perms->expiration);

--- a/fuel/app/classes/materia/msg.php
+++ b/fuel/app/classes/materia/msg.php
@@ -60,6 +60,11 @@ class Msg
 		return new Msg('You do not have permission to access the requested content', 'Permission Denied', Msg::WARN);
 	}
 
+	static public function student_collab()
+	{
+		return new Msg('Students cannot be added as collaborators to widgets that have guest access disabled.', 'Share Not Allowed', Msg::ERROR);
+	}
+
 	static public function student()
 	{
 		return new Msg('Students are unable to receive notifications via Materia', 'No Notifications', Msg::NOTICE);

--- a/src/components/my-widgets-collaborate-dialog.jsx
+++ b/src/components/my-widgets-collaborate-dialog.jsx
@@ -167,8 +167,15 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 		setUserPerms.mutate({
 			instId: inst.id,
 			permsObj: permsObj,
-			successFunc: () => {
-				if (mounted.current) {
+			successFunc: (data) => {
+				if (data && data.type == 'error')
+				{
+					if (data.title == "Share Not Allowed")
+					{
+						setState({...state, shareNotAllowed: true})
+					}
+				}
+				else if (mounted.current) {
 					if (delCurrUser) {
 						queryClient.invalidateQueries('widgets')
 					}

--- a/src/components/notifications.jsx
+++ b/src/components/notifications.jsx
@@ -121,7 +121,11 @@ const Notifications = (user) => {
             instId: notif.item_id,
             permsObj: userPerms,
             successFunc: (data) => {
-                if (data.status == 200)
+                if (!data || data.title == "error")
+                {
+                    setErrorMsg('Action failed.');
+                }
+                else if (data)
                 {
                     // Redirect to widget
                     if (!window.location.pathname.includes('my-widgets'))
@@ -143,11 +147,6 @@ const Notifications = (user) => {
 
                     // Close notifications
                     setNavOpen(false)
-
-                }
-                else
-                {
-                    setErrorMsg('Action failed.');
                 }
             }
         })

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -337,6 +337,10 @@ export const apiGetUserPermsForInstance = instId => {
 
 export const apiSetUserInstancePerms = ({ instId, permsObj }) => {
 	return fetch('/api/json/permissions_set', fetchOptions({ body: `data=${formatFetchBody([objectTypes.WIDGET_INSTANCE, instId, permsObj])}` }))
+	.then(resp => {
+		if (resp.status === 204 || resp.status === 502) return null
+		return resp.json()
+	})
 }
 
 export const apiCanEditWidgets = arrayOfWidgetIds => {


### PR DESCRIPTION
Triggers the Share Not Allowed warning dialog when attempting to add a student to a widget without guest access, even if that student has the support role. When attempting to add multiple users as collaborators, it will add all but students and return an error saying students cannot be added as collaborators.

Fix for #1502