### PR TITLE
Instance list request modifications to fix settings persistence

### DIFF
--- a/fuel/app/classes/materia/widget/instance/manager.php
+++ b/fuel/app/classes/materia/widget/instance/manager.php
@@ -90,6 +90,7 @@ class Widget_Instance_Manager
 
 		$data = [
 			'pagination' => $displayable_inst,
+			'modified'   => time(),
 		];
 		
 		if ($has_next_page) $data['next_page'] = $page_number + 1;

--- a/fuel/app/classes/materia/widget/instance/manager.php
+++ b/fuel/app/classes/materia/widget/instance/manager.php
@@ -89,8 +89,7 @@ class Widget_Instance_Manager
 		$displayable_inst = array_slice($displayable_inst, $offset, $widgets_per_page);
 
 		$data = [
-			'pagination' => $displayable_inst,
-			'modified'   => time(),
+			'pagination' => $displayable_inst
 		];
 		
 		if ($has_next_page) $data['next_page'] = $page_number + 1;

--- a/src/components/hooks/useCopyWidget.jsx
+++ b/src/components/hooks/useCopyWidget.jsx
@@ -36,7 +36,8 @@ export default function useCopyWidget() {
 					pages: previous.pages.map((page, index) => {
 						if (index == 0) return { ...page, pagination: [ newInst, ...page.pagination] }
 						else return page
-					})
+					}),
+					modified: Math.floor(Date.now() / 1000)
 				}))
 
 				return { previousValue }
@@ -51,7 +52,8 @@ export default function useCopyWidget() {
 							return inst
 						}) }
 						else return page
-					})
+					}),
+					modified: Math.floor(Date.now() / 1000)
 				}))
 				variables.successFunc(data)
 			},

--- a/src/components/hooks/useDeleteWidget.jsx
+++ b/src/components/hooks/useDeleteWidget.jsx
@@ -19,7 +19,8 @@ export default function useDeleteWidget() {
 						pages: previous.pages.map((page) => ({
 							...page,
 							pagination: page.pagination.filter(widget => widget.id !== inst.instId)
-						}))
+						})),
+						modified: Math.floor(Date.now() / 1000)
 					}
 				})
 

--- a/src/components/hooks/useUpdateWidget.jsx
+++ b/src/components/hooks/useUpdateWidget.jsx
@@ -16,7 +16,7 @@ export default function useUpdateWidget() {
 				widgetList = queryClient.getQueryData('widgets')
 
 				// widgetList is passed to onSuccess or onError depending on resolution of mutation function
-				return { widgetList }
+				return { ...widgetList }
 			},
 			onSuccess: (updatedInst, variables) => {
 
@@ -26,7 +26,7 @@ export default function useUpdateWidget() {
 						if (inst.id === variables.args[0]) {
 							inst.open_at = `${variables.args[4]}`
 							inst.close_at = `${variables.args[5]}`
-							inst.attempts = `${variables.args[6]}`
+							inst.attempts = parseInt(variables.args[6])
 							inst.guest_access = variables.args[7]
 							inst.embedded_only = variables.args[8]
 							break
@@ -34,9 +34,14 @@ export default function useUpdateWidget() {
 					}
 				}
 				
-
 				// update query cache for widgets. This does NOT invalidate the cache, forcing a re-fetch!!
-				queryClient.setQueryData('widgets', widgetList)
+				queryClient.setQueryData('widgets', previous => {
+					return {
+						...widgetList,
+						modified: Math.floor(Date.now() / 1000)
+					}
+				})
+
 				queryClient.invalidateQueries(['user-perms', variables.args[0]])
 
 				variables.successFunc(updatedInst)

--- a/src/components/hooks/useUpdateWidget.jsx
+++ b/src/components/hooks/useUpdateWidget.jsx
@@ -15,17 +15,21 @@ export default function useUpdateWidget() {
 				await queryClient.cancelQueries('widgets')
 				widgetList = queryClient.getQueryData('widgets')
 
+				console.log(widgetList)
+
 				// widgetList is passed to onSuccess or onError depending on resolution of mutation function
 				return { ...widgetList }
 			},
 			onSuccess: (updatedInst, variables) => {
 
+				console.log(widgetList)
+
 				// update successful - insert new values into our local copy of widgetList
 				for (const page of widgetList?.pages) {
 					for (const inst of page?.pagination) {
 						if (inst.id === variables.args[0]) {
-							inst.open_at = `${variables.args[4]}`
-							inst.close_at = `${variables.args[5]}`
+							inst.open_at = parseInt(variables.args[4])
+							inst.close_at = parseInt(variables.args[5])
 							inst.attempts = parseInt(variables.args[6])
 							inst.guest_access = variables.args[7]
 							inst.embedded_only = variables.args[8]

--- a/src/components/hooks/useUpdateWidget.jsx
+++ b/src/components/hooks/useUpdateWidget.jsx
@@ -15,14 +15,10 @@ export default function useUpdateWidget() {
 				await queryClient.cancelQueries('widgets')
 				widgetList = queryClient.getQueryData('widgets')
 
-				console.log(widgetList)
-
 				// widgetList is passed to onSuccess or onError depending on resolution of mutation function
 				return { ...widgetList }
 			},
 			onSuccess: (updatedInst, variables) => {
-
-				console.log(widgetList)
 
 				// update successful - insert new values into our local copy of widgetList
 				for (const page of widgetList?.pages) {


### PR DESCRIPTION
Resolves #1553 

Even though settings are correctly saved to the server and subsequent pulls from the API include the correct data, the local query cache containing the instance list wasn't being updated because the function that converts the raw query data into the actual instance list is memoized for performance. The `useMemo` hook only does a shallow comparison of objects and would not register the changes applied to an individual instance.

Instead, this PR adds a `modified` value to the local query cache when it is altered locally via `setQueryData` - for example, updating, copying, or deleting an instance. This is recognized by the `useMemo` hook which refreshes the instance list appropriately.

Additionally, the `useUpdateWidget` hook was stringifying certain values that should be integers - as far as I can tell there's no need for them to be strings, when the values from the server are always ints. They've been updated accordingly.

