### PR TITLE
Fix to player component scoreScreenURL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ cd Materia/docker
 ./run_first.sh
 ```
 
-In a separate terminal window, run `yarn dev` to enable the webpack dev server and live reloading while making changes to JS and CSS assets. Materia is configured to run at `https://127.0.0.1` by default.
+The `run_first.sh` script only has to be run once for initial setup. Afterwards, your local copy will persist in a docker volume unless you explicitly use `docker-compose down` or delete the volume manually.
+
+Use `docker-compose up` to run your local instance. The compose process must persist to keep the application alive. Materia is configured to run at `https://127.0.0.1` by default.
+
+In a separate terminal window, run `yarn dev` to enable the webpack dev server and live reloading while making changes to JS and CSS assets. 
 
 Note that Materia uses a self-signed certificate to facilitate https traffic locally. Your browser may require security exceptions for both `127.0.0.1:443` and `127.0.0.1:8008`.
 

--- a/src/components/widget-player.jsx
+++ b/src/components/widget-player.jsx
@@ -104,7 +104,6 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 	const [pendingLogs, dispatchPendingLogs] = useReducer(logReducer, initLogs())
 	const [playState, setPlayState] = useState('init')
 
-	const [scoreScreenURL, setScoreScreenURL] = useState('')
 	const [readyForScoreScreen, setReadyForScoreScreen] = useState(false)
 	const [retryCount, setRetryCount] = useState(0) // retryCount's value is referenced within the function passed to setRetryCount
 	const [queueProcessing, setQueueProcessing] = useState(false)
@@ -116,6 +115,7 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 	// refs are used instead of state when value updates do not require a component rerender
 	const centerRef = useRef(null)
 	const frameRef = useRef(null)
+	const scoreScreenUrlRef = useRef(null)
 
 	/*********************** queries ***********************/
 
@@ -211,7 +211,7 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 				height: `${inst.widget.height}px`
 			})
 
-			setScoreScreenURL(() => {
+			scoreScreenUrlRef.current = () => {
 				let _scoreScreenURL = ''
 				if (isPreview) {
 					_scoreScreenURL = `${window.BASE_URL}scores/preview/${instanceId}`
@@ -221,7 +221,7 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 					_scoreScreenURL = `${window.BASE_URL}scores/${instanceId}#play-${playId}`
 				}
 				return _scoreScreenURL
-			})
+			}
 		}
 	}, [inst, qset])
 
@@ -237,13 +237,6 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 		}
 	},[alert])
 
-	// addresses a special case where queue processing needs to be deferred until the scoreScreenURL state object is updated
-	// if not, score_url passed by a response to play_logs_save may not be properly updated in time before the widget is completed
-	useEffect(() => {
-		if (playState == 'pending' || playState == 'playing' && queueProcessing) {
-			setQueueProcessing(false)
-		}
-	},[scoreScreenURL])
 
 	// hook associated with log queue management
 	useEffect(() => {
@@ -276,8 +269,8 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 
 	/******* !!!!!! this is the hook that actually navigates to the score screen !!!!! *******/
 	useEffect(() => {
-		if (playState == 'end' && readyForScoreScreen && scoreScreenURL) {
-			window.location.assign(scoreScreenURL)
+		if (playState == 'end' && readyForScoreScreen && scoreScreenUrlRef.current) {
+			window.location.assign(scoreScreenUrlRef.current)
 		}
 	}, [playState, readyForScoreScreen])
 
@@ -387,7 +380,6 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 			request: logQueue[0].request,
 			successFunc: (result) => {
 
-				let deferProcessingComplete = false
 				setRetryCount(0) // reset on success
 
 				if (result) {
@@ -399,10 +391,8 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 					logQueue.shift()
 
 					// score_url is sent from the server to redirect to a specific url
-					// defer queue processing completion until after the state value is updated
 					if (result.score_url) {
-						deferProcessingComplete = true
-						setScoreScreenURL(result.score_url)
+						scoreScreenUrlRef.current = result.score_url
 					} else if (result.type === 'error') {
 
 						setAlert({
@@ -414,7 +404,7 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 				}
 
 				if (logQueue.length > 0) _pushPendingLogs(logQueue)
-				else if (!deferProcessingComplete) setQueueProcessing(false)
+				else setQueueProcessing(false)
 			},
 			failureFunc: () => {
 				setRetryCount((oldCount) => {


### PR DESCRIPTION
Resolves #1558. This is a high priority issue.

The `widget-player` component assigns a default value to the `scoreScreenURL` state object, but if played in an LTI context, the `on_play_completed_event` returns a `score_url` value that's appended to the response object of `play_logs_save` if the score module reports the play is completed.

The problem is that the `scoreScreenURL` state object is updated independently of the rest of the component's state values that manage the overall player state. As best I can tell, under certain circumstances, the `scoreScreenURL` is not updated before the `playState` state value, and the hook responsible for navigating to the score screen fires with the old `scoreScreenURL` value instead. Because of the nature of the race condition, this is very difficult to test.

This PR:
~~Defers the `queueProcessing` flag from being reset to `false` if the `score_url` value is present in the response until after the `scoreScreenURL` is properly updated (via another `useEffect` hook). The `queueProcessing` flag must be false before the `playState` is updated to `end`, which is one of the trigger conditions for navigating to the score screen~~

Replaces the `scoreScreenURL` state object with a `useRef` hook, which is updated immediately and maintained across renders.