### PR TITLE
Triage fixes for LTI score passback bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ cd Materia/docker
 ./run_first.sh
 ```
 
-In a separate terminal window, run `yarn dev` to enable the webpack dev server and live reloading while making changes to JS and CSS assets. Materia is configured to run at `https://127.0.0.1` by default.
+The `run_first.sh` script only has to be run once for initial setup. Afterwards, your local copy will persist in a docker volume unless you explicitly use `docker-compose down` or delete the volume manually.
+
+Use `docker-compose up` to run your local instance. The compose process must persist to keep the application alive. Materia is configured to run at `https://127.0.0.1` by default.
+
+In a separate terminal window, run `yarn dev` to enable the webpack dev server and live reloading while making changes to JS and CSS assets. 
 
 Note that Materia uses a self-signed certificate to facilitate https traffic locally. Your browser may require security exceptions for both `127.0.0.1:443` and `127.0.0.1:8008`.
 

--- a/src/components/widget-player.jsx
+++ b/src/components/widget-player.jsx
@@ -104,7 +104,6 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 	const [pendingLogs, dispatchPendingLogs] = useReducer(logReducer, initLogs())
 	const [playState, setPlayState] = useState('init')
 
-	const [scoreScreenURL, setScoreScreenURL] = useState('')
 	const [readyForScoreScreen, setReadyForScoreScreen] = useState(false)
 	const [retryCount, setRetryCount] = useState(0) // retryCount's value is referenced within the function passed to setRetryCount
 	const [queueProcessing, setQueueProcessing] = useState(false)
@@ -116,6 +115,7 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 	// refs are used instead of state when value updates do not require a component rerender
 	const centerRef = useRef(null)
 	const frameRef = useRef(null)
+	const scoreScreenUrlRef = useRef(null)
 
 	/*********************** queries ***********************/
 
@@ -211,7 +211,7 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 				height: `${inst.widget.height}px`
 			})
 
-			setScoreScreenURL(() => {
+			scoreScreenUrlRef.current = () => {
 				let _scoreScreenURL = ''
 				if (isPreview) {
 					_scoreScreenURL = `${window.BASE_URL}scores/preview/${instanceId}`
@@ -221,7 +221,7 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 					_scoreScreenURL = `${window.BASE_URL}scores/${instanceId}#play-${playId}`
 				}
 				return _scoreScreenURL
-			})
+			}
 		}
 	}, [inst, qset])
 
@@ -237,13 +237,6 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 		}
 	},[alert])
 
-	// addresses a special case where queue processing needs to be deferred until the scoreScreenURL state object is updated
-	// if not, score_url passed by a response to play_logs_save may not be properly updated in time before the widget is completed
-	useEffect(() => {
-		if (playState == 'pending' || playState == 'playing' && queueProcessing) {
-			setQueueProcessing(false)
-		}
-	},[scoreScreenURL])
 
 	// hook associated with log queue management
 	useEffect(() => {
@@ -276,8 +269,8 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 
 	/******* !!!!!! this is the hook that actually navigates to the score screen !!!!! *******/
 	useEffect(() => {
-		if (playState == 'end' && readyForScoreScreen && scoreScreenURL) {
-			window.location.assign(scoreScreenURL)
+		if (playState == 'end' && readyForScoreScreen && scoreScreenUrlRef.current) {
+			window.location.assign(scoreScreenUrlRef.current)
 		}
 	}, [playState, readyForScoreScreen])
 
@@ -387,7 +380,6 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 			request: logQueue[0].request,
 			successFunc: (result) => {
 
-				let deferProcessingComplete = false
 				setRetryCount(0) // reset on success
 
 				if (result) {
@@ -399,10 +391,8 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 					logQueue.shift()
 
 					// score_url is sent from the server to redirect to a specific url
-					// defer queue processing completion until after the state value is updated
 					if (result.score_url) {
-						deferProcessingComplete = true
-						setScoreScreenURL(result.score_url)
+						scoreScreenUrlRef.current = result.score_url
 					} else if (result.type === 'error') {
 
 						setAlert({
@@ -414,7 +404,7 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 				}
 
 				if (logQueue.length > 0) _pushPendingLogs(logQueue)
-				else if (!deferProcessingComplete) setQueueProcessing(false)
+				else setQueueProcessing(false)
 			},
 			failureFunc: () => {
 				setRetryCount((oldCount) => {


### PR DESCRIPTION
The bug:

As of `v10.0.1-rc.1` and a database running MySQL 8, there appears to be a bug associated with the `DB` session driver where values written to user sessions don't persist. Specifically, the `lti-link-<play_id>` values written when a user replays an instance in an LTI context goes missing. This has multiple downstream impacts, most importantly that upon submission, a replay isn't considered an LTI play and the score is not returned to the LTI provider. It's not yet clear if the underlying cause is related to:

- Changes between MySQL 5.7 and 8 that cause session writes to sometimes go bad
- Issues with session rotation, specifically when the Session table is under significant load
- Issues with FuelPHP 1.9 AND MySQL 8 or some combination of the above

Until the core issue can be identified, this PR serves as a stopgap measure. Changes include:

- Modifies `scoreScreenUrl` in the `widget-player` component to use `useRef` instead of state. While this didn't fix the core issue, it potentially alleviates a race condition.
- Adds `auth` and `environment_data` values to the `\Materia\Session\Play` instance properties when requested via `get_by_id`. These are were not previously included in the DB query.
- Adds "triage" fallback logic to the `ltievents` class when requesting `lti-link-<play_id>` from session. If the token value is not present in session, it interrogates (or creates and then interrogates) a play instance for the `auth` and `environment_data` properties. The play's environment data will include the `token` value that was supposed to be stored in session.