### PR TITLE
Custom score screen qset acquisition changes

### DIFF
--- a/fuel/app/classes/materia/api/v1.php
+++ b/fuel/app/classes/materia/api/v1.php
@@ -42,18 +42,18 @@ class Api_V1
 		return Widget_Manager::get_widgets([], $type);
 	}
 
-	static public function widget_instances_get($inst_ids = null, bool $deleted = false, $load_qset = false)
+	static public function widget_instances_get($inst_ids = null, bool $deleted = false)
 	{
 		// get all my instances - must be logged in
 		if (empty($inst_ids))
 		{
 			if (\Service_User::verify_session() !== true) return []; // shortcut to returning noting
-			return Widget_Instance_Manager::get_all_for_user(\Model_User::find_current_id(), $load_qset);
+			return Widget_Instance_Manager::get_all_for_user(\Model_User::find_current_id());
 		}
 
 		// get specific instances - no log in required
 		if ( ! is_array($inst_ids)) $inst_ids = [$inst_ids]; // convert string into array of items
-		return Widget_Instance_Manager::get_all($inst_ids, $load_qset, false, $deleted);
+		return Widget_Instance_Manager::get_all($inst_ids, false, false, $deleted);
 	}
 
 /**

--- a/fuel/app/classes/materia/score/manager.php
+++ b/fuel/app/classes/materia/score/manager.php
@@ -272,7 +272,14 @@ class Score_Manager
 		// format results for the scorescreen
 		$details = $score_module->get_score_report();
 
-		return [$details];
+		$inst->get_qset($inst->id, $play_logs[0]->created_at);
+
+		return [
+			[
+				...$details,
+				'qset' => $inst->qset
+			]
+		];
 	}
 
 }

--- a/fuel/app/classes/materia/score/manager.php
+++ b/fuel/app/classes/materia/score/manager.php
@@ -96,6 +96,11 @@ class Score_Manager
 			$details = $score_module->get_score_report();
 
 			$return_arr[] = $details;
+
+			// append qset to the details array
+			// required for custom score screens & contextually provided per play, since some plays may use an earlier qset version
+			$inst->get_qset($inst_id, $play->created_at);
+			$return_arr[0]['qset'] = $inst->qset;
 		}
 		return $return_arr;
 	}

--- a/fuel/app/classes/materia/widget/instance/manager.php
+++ b/fuel/app/classes/materia/widget/instance/manager.php
@@ -62,11 +62,11 @@ class Widget_Instance_Manager
 		return $instances;
 	}
 
-	public static function get_all_for_user($user_id, $load_qset=false)
+	public static function get_all_for_user($user_id)
 	{
 		$inst_ids = Perm_Manager::get_all_objects_for_user($user_id, Perm::INSTANCE, [Perm::FULL, Perm::VISIBLE]);
 
-		if ( ! empty($inst_ids)) return self::get_all($inst_ids, $load_qset);
+		if ( ! empty($inst_ids)) return self::get_all($inst_ids);
 		else return [];
 	}
 

--- a/fuel/app/tests/api/v1.php
+++ b/fuel/app/tests/api/v1.php
@@ -135,17 +135,6 @@ class Test_Api_V1 extends \Basetest
 			$this->assertNull($value->qset->version);
 		}
 
-		// ----- loads specific instance with qset --------
-		$output = Api_V1::widget_instances_get($instance->id, false, true);
-		$this->assertIsArray($output);
-		$this->assertCount(1, $output);
-		foreach ($output as $key => $value)
-		{
-			$this->assert_is_widget_instance($value, true);
-			$this->assertObjectHasAttribute('qset', $value);
-			$this->assert_is_qset($value->qset);
-		}
-
 		// ======= STUDENT ========
 		$this->_as_student();
 		$output = Api_V1::widget_instances_get();

--- a/src/components/score-details.jsx
+++ b/src/components/score-details.jsx
@@ -4,7 +4,7 @@ import ScoreGraphic from './score-graphic'
 const ScoreDetails = ({details, complete}) => {
 	
 	let detailsRender = []
-	details.forEach((detail, i) => {
+	details?.forEach((detail, i) => {
 		let detailsTableRows = []
 		let detailsHeaders = []
 		detail.table.forEach((row, j) => {

--- a/src/components/scores.jsx
+++ b/src/components/scores.jsx
@@ -27,7 +27,7 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 	const [attemptNum, setAttemptNum] = useState(null)
 
 	const [overview, setOverview] = useState()
-	const [details, setDetails] = useState([])
+	const [playDetails, setPlayDetails] = useState(null)
 	const [prevAttemptOpen, setprevAttemptOpen] = useState(false)
 
 	// set to one of the state constants above if an error state manifests
@@ -186,7 +186,7 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 
 	// Initializes the custom score screen
 	useEffect(() => {
-		if (instance) {
+		if (instance && playDetails) {
 			let enginePath
 			const score_screen = instance.widget.score_screen
 			// custom score screen exists?
@@ -206,7 +206,6 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 					setCustomScoreScreen({
 						...customScoreScreen,
 						htmlPath: enginePath + '?' + instance.widget.created_at,
-						qset: instance.qset,
 						scoreTable: scoreTable,
 						type: 'html',
 						loading: false,
@@ -222,7 +221,7 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 				setCustomScoreScreen({ ...customScoreScreen, loading: false })
 			}
 		}
-	}, [instance, scoreTable])
+	}, [instance, playDetails, scoreTable])
 
 	// _displayAttempts
 	useEffect(() => {
@@ -287,7 +286,7 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 		if (playScores && playScores.length > 0) {
 
 			const deets = playScores[0]
-			setDetails([...deets.details])
+			setPlayDetails({qset: { ...deets.qset }, details: [ ...deets.details ]})
 
 			let score
 
@@ -491,7 +490,7 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 	// this is only called in response from the score-core
 	// it will not be called for default score screens
 	const _sendWidgetInit = () => {
-		if (customScoreScreen.scoreTable == null || customScoreScreen.qset == null || scoreWidgetRef.current == null) {
+		if (customScoreScreen.scoreTable == null || playDetails == null || scoreWidgetRef.current == null) {
 			// Custom score screen failed to load, load default overview instead
 			setCustomScoreScreen({ ...customScoreScreen, loading: true, show: false })
 			setShowResultsTable(true)
@@ -500,12 +499,12 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 		}
 		setCustomScoreScreen({ ...customScoreScreen, ready: true })
 
-		_sendToWidget('initWidget', [customScoreScreen.qset, customScoreScreen.scoreTable, instance, isPreview, window.MEDIA_URL])
+		_sendToWidget('initWidget', [playDetails.qset, customScoreScreen.scoreTable, instance, isPreview, window.MEDIA_URL])
 	}
 
 	// tell the custom score screen that the selected attempt/play has changed, and pass the new scoreTable accordingly
 	const _sendWidgetUpdate = () => {
-		_sendToWidget('updateWidget', [instance.qset, scoreTable])
+		_sendToWidget('updateWidget', [playDetails.qset, scoreTable])
 	}
 
 	const _setHeight = (h) => {
@@ -672,7 +671,7 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 			</section>
 		)
 	} else if (!errorStateRender && showResultsTable) {
-		detailsRender = <ScoreDetails details={details} complete={overview?.complete} />
+		detailsRender = <ScoreDetails details={playDetails?.details} complete={overview?.complete} />
 	}
 
 	return (

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -18,8 +18,8 @@ const fetchGet = (url, options = null) => fetch(url, fetchOptions(options)).then
 // Helper function to simplify encoding fetch body values
 const formatFetchBody = body => encodeURIComponent(JSON.stringify(body))
 
-export const apiGetWidgetInstance = (instId, loadQset=false) => {
-	return fetch(`/api/json/widget_instances_get/`, fetchOptions({ body: `data=${formatFetchBody([instId, false, loadQset])}` }))
+export const apiGetWidgetInstance = (instId) => {
+	return fetch(`/api/json/widget_instances_get/`, fetchOptions({ body: `data=${formatFetchBody([instId])}` }))
 		.then(resp => {
 			if (resp.status === 204 || resp.status === 502) return []
 			return resp.json()


### PR DESCRIPTION
Previously, the qset sent to the score screen was bundled with instance information as part of the `widget_instances_get` API call. Unfortunately this only ever provided the newest copy of a qset, which poses a problem when reviewing older plays that used older copies of a qset, since the IDs for individual items would not match (if they existed at all). 

This PR instead attaches the qset to the response object of `widget_instance_play_scores_get`, which is called when the score screen requests detailed information for a given play. Since the response object already contains a pair of properties, `overview` and `details`, the hope is it makes intuitive sense to attach the `qset` property adjacent to those. The qset provided will match the qset used in each play.

In addition to updating the score manager's `get_play_details` method with the above, the additional parameter for `widget_instances_get` and the associated changes made to support it have been removed.

