### PR TITLE
Save History fix for new instances

### DIFF
--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -228,7 +228,7 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 			// this hook will then fire a second time when a new save postMessage is sent
 			// the second hook will initialize an existing widget with the newly provided qset data
 			// note: this condition will also apply when rolling back and applying the original cached qset
-			if (!!instId && instance.qset && creatorState.reloadWithQset) {
+			if (!!instIdRef.current && instance.qset && creatorState.reloadWithQset) {
 
 				// flip to false because creator will re-init and send start postMessage
 				setWidgetReady(false)
@@ -240,14 +240,14 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 				// tell creator to manually reload
 				sendToCreator('reloadCreator')
 
-			} else if (!!instId && instance.qset) {
+			} else if (!!instIdRef.current && instance.qset) {
 
 				let args = [instance.name, instance, instance.qset.data, instance.qset.version, window.BASE_URL, window.MEDIA_URL]
 				sendToCreator('initExistingWidget', args)
 
 				creatorShouldInitRef.current = false
 
-			} else if (!instId) {
+			} else if (!instIdRef.current) {
 
 				let args = [instance.widget, window.BASE_URL, window.MEDIA_URL]
 				sendToCreator('initNewWidget', args)
@@ -407,6 +407,7 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 						break
 					case 'save':
 						setSaveWidgetComplete(saveModeRef.current)
+						if (!instIdRef.current) instIdRef.current = inst.id
 						setInstance(currentInstance => ({ ...currentInstance, ...inst }))
 						sendToCreator('onSaveComplete', [
 							inst.name,


### PR DESCRIPTION
A couple spots in the creator component were using references to the `instId` prop, which is `undefined` or `null` when a new instance is initialized. The value is never updated retroactively, so hooks that prompt the creator to reload via Save History would initialize another new instance instead of using the `initExistingWidget` path.

Updated a couple references to the `instId` prop to reference `instIdRef`'s `current` value instead, and ensured that ref value is updated after the instance is saved (and a fresh instance ID is provided). 