### PR TITLE
Support users can view instance scores

### DIFF
--- a/src/components/my-widgets-score-semester.jsx
+++ b/src/components/my-widgets-score-semester.jsx
@@ -93,12 +93,16 @@ const MyWidgetScoreSemester = ({semester, instId, hasScores}) => {
 
 	return (
 		<div className='scoreWrapper'>
-			<h3 className='view'>{semester.term} {semester.year}</h3>
-			<ul className='choices'>
-				{ standardTabElementsRender }
-				{ storageTabRender }
-			</ul>
-			{ activeTab }
+			<section className='scores-header'>
+				<h3 className='semester-label'>{semester.term} {semester.year}</h3>
+				<ul className='choices'>
+					{ standardTabElementsRender }
+					{ storageTabRender }
+				</ul>
+			</section>
+			<section className='scores-tab-content'>
+				{ activeTab }
+			</section>
 		</div>
 	)
 }

--- a/src/components/my-widgets-scores.jsx
+++ b/src/components/my-widgets-scores.jsx
@@ -97,13 +97,15 @@ const MyWidgetsScores = ({inst, beardMode}) => {
 
 	return (
 		<div className='scores'>
-			<h2>Student Activity</h2>
-			<span id='export_scores_button'
-			className={`aux_button ${inst.is_draft ? 'disabled' : ''}`}
-			onClick={openExport}>
-				<span className='arrow_down'></span>
-				Export Options
-			</span>
+			<header className='student-activity-header'>
+				<h2>Student Activity</h2>
+				<span
+					className={`action_button ${inst.is_draft ? 'disabled' : ''}`}
+					onClick={openExport}>
+					<span className='arrow_down'></span>
+					Export Options
+				</span>
+			</header>
 			{ contentRender }
 			{ exportRender }
 		</div>

--- a/src/components/my-widgets-scores.scss
+++ b/src/components/my-widgets-scores.scss
@@ -10,12 +10,27 @@
 	overflow-y: auto;
 	padding-bottom: 1em;
 
-	#export_scores_button.disabled,
-	#export_scores_button.disabled:hover {
-		background: #d4d4d4;
-		color: #545454;
-		cursor: default;
-		opacity: 0.5;
+	.student-activity-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 0;
+
+		border-bottom: #999 dotted 1px;
+	
+		.action_button {
+			
+			color: $extremely-dark-gray;
+			text-shadow: 1px 1px 1px rgba(255, 255, 255, 0.5);
+			box-shadow: 1px 2px 4px #ececec;
+
+			&.disabled, &.disabled:hover {
+				background: #d4d4d4;
+				color: #545454;
+				cursor: default;
+				opacity: 0.5;
+			}
+		}
 	}
 
 	.graph {
@@ -40,79 +55,100 @@
 		}
 	}
 
-	h2 {
-		border-bottom: #999 dotted 1px;
-		padding-bottom: 14px;
-		padding-top: 2px;
-		padding-bottom: 13px;
-		margin-bottom: 0;
-	}
-
 	h3 {
 		color: #000000;
 	}
 
-	#export_scores_button {
-		padding: 7px 23px 8px 23px;
-		background-color: $color-yellow;
-		font-weight: 700;
-		color: $extremely-dark-gray;
-		text-shadow: 1px 1px 1px rgba(255, 255, 255, 0.5);
-		box-shadow: 1px 2px 4px #ececec;
-		font-size: 18px;
-		cursor: pointer;
-		display: inline-block;
-		user-select: none;
-		// border: 1px solid #525252;
-		border-radius: 4px;
-		position: absolute;
-		top: 13px;
-		right: 2px;
-
-		&:hover:not(.disabled) {
-			background: $color-yellow-hover;
-			text-decoration: none;
-		}
-
-		&.disabled {
-			color: #545454;
-			cursor: auto;
-		}
-	}
+	
 
 	.scoreWrapper {
-		display: inline-block;
+		display: flex;
+		justify-content: flex-start;
+		flex-direction: column;
 		position: relative;
 		margin-top: 1em;
 
-		ul.choices {
-			display: inline-block;
-			margin: 15px 0 0 0;
-			padding: 0;
-			height: 23px;
+		.scores-header {
+			display: flex;
+			flex-direction: row;
+			justify-content: flex-start;
+			align-items: flex-end;
 
-			li {
-				list-style: none;
-				display: inline-block;
-				padding-right: 3px;
-
-				a {
-					color: #000000;
-					padding: 6px 10px 4px 10px;
-					border-left: solid #dbdbdb 1px;
-					border-top: solid #dbdbdb 1px;
-					border-right: solid #dbdbdb 1px;
-					padding-bottom: 5px;
-					cursor: pointer;
-
-					&:hover {
-						text-decoration: none;
-					}
-				}
+			h3.semester-label {
+				display: block;
+				width: auto;
+				margin: 0.25em 0.5em 0.15em 0;
+				padding: 0;
 			}
 
-			li.scoreTypeSelected a {
-				background: #f3f3f3;
+			ul.choices {
+				display: inline-block;
+				width: auto;
+				margin: 15px 0 0 0;
+				padding: 0;
+				height: 23px;
+	
+				li {
+					list-style: none;
+					display: inline-block;
+					padding-right: 3px;
+	
+					a {
+						color: #000000;
+						padding: 6px 10px 4px 10px;
+						border-left: solid #dbdbdb 1px;
+						border-top: solid #dbdbdb 1px;
+						border-right: solid #dbdbdb 1px;
+						padding-bottom: 5px;
+						cursor: pointer;
+	
+						&:hover {
+							text-decoration: none;
+						}
+					}
+				}
+	
+				li.scoreTypeSelected a {
+					background: #f3f3f3;
+				}
+			}
+		}
+
+		.scores-tab-content {
+			display: flex;
+			justify-content: space-between;
+			gap: 0.5em;
+
+			.numeric {
+				width: 105px;
+				margin: 0;
+				padding: 0;
+	
+				li {
+					padding: 5px;
+					margin: 0 0 10px 0;
+
+					list-style: none;
+
+					text-align: center;
+					background: #e9edef;
+					border-radius: 5px;
+	
+					p {
+						padding: 0;
+						margin: 0;
+						color: #0093e7;
+						text-align: center;
+						font-size: 2em;
+						font-weight: 900;
+						font-family: 'Kameron', Georgia, 'Times New Roman', Times, serif;
+					}
+	
+					h4 {
+						padding: 0;
+						margin: 0;
+					}
+				}
 			}
 		}
 
@@ -133,19 +169,13 @@
 			}
 		}
 
-		h3.view {
-			display: inline-block;
-			margin: 15px 0.5em 0 0;
-			padding: 0;
-		}
-
 		.display.graph {
 			background: #ffffff;
 			margin: 0;
 			padding: 20px 0 0 20px;
 			border: solid #dbdbdb 1px;
-			width: 550px;
-			float: left;
+			// width: 550px;
+			// float: left;
 
 			.type {
 				padding: 0;
@@ -330,7 +360,6 @@
 
 			.score-search {
 				background: rgba(0, 0, 0, 0.05);
-				width: 100%;
 				padding: 6px 10px 10px 10px;
 
 				input[type='text'] {
@@ -446,36 +475,6 @@
 
 			tbody tr.rowSelected {
 				background: #ffcb68;
-			}
-		}
-
-		.numeric {
-			float: left;
-			margin: 0;
-			padding: 0;
-			width: 105px;
-
-			li {
-				list-style: none;
-				text-align: center;
-				background: #e9edef;
-				padding: 5px;
-				margin: 0 0 10px 0;
-
-				p {
-					padding: 0;
-					margin: 0;
-					color: #0093e7;
-					text-align: center;
-					font-size: 2em;
-					font-weight: 900;
-					font-family: 'Kameron', Georgia, 'Times New Roman', Times, serif;
-				}
-
-				h4 {
-					padding: 0;
-					margin: 0;
-				}
 			}
 		}
 	}

--- a/src/components/support-page.jsx
+++ b/src/components/support-page.jsx
@@ -35,8 +35,8 @@ const SupportPage = () => {
 
 
 	useEffect(() => {
-		if (Array.isArray(instFromHash) && instFromHash.length > 0) {
-			setSelectedInstance(instFromHash[[0]])
+		if (instFromHash && instFromHash.pagination && instFromHash.pagination.length > 0) {
+			setSelectedInstance(instFromHash.pagination[0])
 		}
 	},[instFromHash])
 

--- a/src/components/support-page.scss
+++ b/src/components/support-page.scss
@@ -266,14 +266,16 @@
 				margin: 0px 0px;
 			}
 
-			.right-justify {
-				margin-top: 20px;
+			.bottom-buttons {
 				display: flex;
-				justify-content: flex-end;
+				justify-content: space-between;
+
+				margin-top: 20px;
 
 				.apply-changes {
 					display: flex;
 					flex-direction: column;
+					justify-self: flex-end;
 					justify-content: flex-end;
 					width: 220px;
 

--- a/src/components/support-selected-instance.jsx
+++ b/src/components/support-selected-instance.jsx
@@ -10,6 +10,7 @@ import MyWidgetsCopyDialog from './my-widgets-copy-dialog'
 import MyWidgetsCollaborateDialog from './my-widgets-collaborate-dialog'
 import ExtraAttemptsDialog from './extra-attempts-dialog'
 import useCopyWidget from './hooks/useSupportCopyWidget'
+import MyWidgetsScores from './my-widgets-scores'
 
 const addZero = i => `${i}`.padStart(2, '0')
 
@@ -39,6 +40,7 @@ const SupportSelectedInstance = ({inst, currentUser, embed = false}) => {
 	const [showCopy, setShowCopy] = useState(false)
 	const [showCollab, setShowCollab] = useState(false)
 	const [showAttempts, setShowAttempts] = useState(false)
+	const [showScoreDetails, setShowScoreDetails] = useState(false)
 	const [availableDisabled, setAvailableDisabled] = useState(inst.open_at < 0)
 	const [availableDate, setAvailableDate] = useState(inst.open_at < 0 ? '' : objToDateString(inst.open_at))
 	const [availableTime, setAvailableTime] = useState(inst.open_at < 0 ? '' : objToTimeString(inst.open_at))
@@ -247,6 +249,11 @@ const SupportSelectedInstance = ({inst, currentUser, embed = false}) => {
 			</div>
 	}
 
+	let scoresContainer = null
+	if (showScoreDetails) {
+		scoresContainer = <MyWidgetsScores inst={inst} beardMode={false} />
+	}
+
 	return (
 		<section className='page inst-info'>
 			{ breadcrumbContainer }
@@ -437,7 +444,8 @@ const SupportSelectedInstance = ({inst, currentUser, embed = false}) => {
 						{updatedInst.preview_url}
 					</a>
 				</div>
-				<div className='right-justify'>
+				<div className='bottom-buttons'>
+					<button className='action_button' onClick={() => setShowScoreDetails(!showScoreDetails)}>Scores</button>
 					<div className='apply-changes'>
 						<button className='action_button apply'
 							onClick={applyChanges}>
@@ -452,6 +460,10 @@ const SupportSelectedInstance = ({inst, currentUser, embed = false}) => {
 			{ copyDialogRender }
 			{ collaborateDialogRender }
 			{ extraAttemptsDialogRender }
+
+			<section>
+				{ scoresContainer }
+			</section>
 		</section>
 	)
 }

--- a/src/components/user-admin-page.scss
+++ b/src/components/user-admin-page.scss
@@ -312,7 +312,6 @@
 			&.instances {
 
 				ul {
-					width: 100%;
 					padding: 0;
 					flex-direction: row;
 					list-style-type: none;
@@ -401,6 +400,22 @@
 								border-bottom-right-radius: 3px;
 
 								line-height: 1.5em;
+
+								.inst-info {
+
+									.bottom-buttons {
+										display: flex;
+										justify-content: space-between;
+										margin-top: 20px;
+									}
+								}
+
+								.scores {
+									margin: 1em 0 0 0;
+									padding: 10px;
+									background: #fff;
+									border-radius: 5px;
+								}
 							}
 						}
 					}

--- a/src/components/user-admin-page.scss
+++ b/src/components/user-admin-page.scss
@@ -332,6 +332,8 @@
 
 						border-radius: 3px;
 
+						line-height: 1.5em;
+
 						.img-holder {
 							display: inline-block;
 							vertical-align: middle;
@@ -429,6 +431,7 @@
 							}
 							.overview {
 								padding: 10px;
+								line-height: 1.25em;
 
 								div {
 									margin: 5px 0px;
@@ -464,22 +467,21 @@
 										}
 									}
 								}
-								line-height: 1.5em;
+							}
 
-								.inst-info {
-
-									.bottom-buttons {
-										display: flex;
-										justify-content: space-between;
-										margin-top: 20px;
-									}
-								}
+							.inst-info {
 
 								.scores {
 									margin: 1em 0 0 0;
 									padding: 10px;
 									background: #fff;
 									border-radius: 5px;
+								}
+
+								.bottom-buttons {
+									display: flex;
+									justify-content: space-between;
+									margin-top: 20px;
 								}
 							}
 						}

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -383,7 +383,7 @@ export const apiGetWidgetLock = (id = null) => {
  * @param {string} input (letters only)
  * @returns {array} of matches
  */
-export const apiSearchInstances = (input, page_number) => {
+export const apiSearchInstances = (input, page_number = 0) => {
 	let pattern = /[A-Za-z]+/g
 	let match = input.match(pattern)
 	if (!match || !match.length) input = ' '


### PR DESCRIPTION
Resolves #1457 (related to Support Users viewing scores)

- Implements the `MyWidgetsScores` and child components in the instance admin panel, allowing a support or super user to review all score details associated with a given instance. No changes were needed to allow support users access to play logs they do not have explicit access to.

- Fixes a bug where directly accessing an instance from the instance admin URL + widget hash was no longer working.

- CSS overhaul of score summary table to make it more responsive, previously it would break visually when viewed in the instance manager embedded within user admin.