### PR TITLE
Prevents play score percentages over 100

### DIFF
--- a/fuel/app/classes/materia/score/manager.php
+++ b/fuel/app/classes/materia/score/manager.php
@@ -152,6 +152,9 @@ class Score_Manager
 		$semesters = [];
 		foreach ($result as $log)
 		{
+			// remove any erroneous > 100% scores from the distribution graph
+			if ($log['bracket'] > 9) continue;
+
 			$key = $log['id'];
 			if ( ! isset($semesters[$key]))
 			{

--- a/fuel/app/classes/materia/session/play.php
+++ b/fuel/app/classes/materia/session/play.php
@@ -368,6 +368,9 @@ class Session_Play
 
 	public function set_complete($score, $possible, $percent)
 	{
+		// ensure percent is never inadvertently set to a value over 100, which will break things
+		if ($percent > 100) $percent = 100;
+
 		// set max score to the current score
 		$max_percent = $percent;
 


### PR DESCRIPTION
Resolves #1392 

This is a single-line addition to the `Session_Play` class to ensure the `$percent` param submitted to `set_complete` is never allowed to be over 100. While the database will happily accept values over 100, certain places downstream will have major issues with play percentages that are out of bounds.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207543795708273