### PR TITLE
Fixes/improves expired preview log handling

### DIFF
--- a/fuel/app/classes/materia/api/v1.php
+++ b/fuel/app/classes/materia/api/v1.php
@@ -655,7 +655,9 @@ class Api_V1
 		if (Util_Validator::is_valid_hash($preview_mode_inst_id))
 		{
 			$inst = Widget_Instance_Manager::get($preview_mode_inst_id);
-			return Score_Manager::get_preview_logs($inst);
+			$preview_logs = Score_Manager::get_preview_logs($inst);
+			if ( ! is_array($preview_logs)) return Msg::expired();
+			else return $preview_logs;
 		}
 		else
 		{

--- a/fuel/app/classes/materia/msg.php
+++ b/fuel/app/classes/materia/msg.php
@@ -80,4 +80,10 @@ class Msg
 		$msg = new Msg($msg, $title, Msg::ERROR, false, 404);
 		return $msg;
 	}
+
+	static public function expired($msg = 'The requested content has expired and is no longer available', $title = 'expired')
+	{
+		$msg = new Msg($msg, $title, Msg::ERROR, false, 410);
+		return $msg;
+	}
 }

--- a/src/components/scores.jsx
+++ b/src/components/scores.jsx
@@ -119,6 +119,7 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 		staleTime: Infinity,
 		enabled: (!!playId || !!previewInstId),
 		refetchOnWindowFocus: false,
+		retry: false,
 		onError: (err) => {
 			if (err.message == "Invalid Login") {
 				setErrorState(STATE_RESTRICTED)


### PR DESCRIPTION
One overlooked change to the API error state improvements is the way expired preview logs are handled; they no longer tripped the Preview Expired view rendering because the API was returning a `204` instead of an error code. This small PR adds a new `expired()` static method to the Materia `Msg` class, which returns a `410` response (Gone) instead of a `204`. Note that the associated react query has `retry: false` applied to reduce the delay between error receipt and the Expired Preview view being rendered.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207533547776226