### PR TITLE
Adds php-fpm config override to adjust pm.max_children value

### DIFF
--- a/docker/config/php/materia.www.conf
+++ b/docker/config/php/materia.www.conf
@@ -1,0 +1,5 @@
+[www]
+
+; 5 is the default value given to pm.max_children
+; this config is loaded after the default www.conf, allowing easy overrides of the pm.max_children setting
+pm.max_children = 5

--- a/materia-app.Dockerfile
+++ b/materia-app.Dockerfile
@@ -45,6 +45,12 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 # Modify php-fpm.d/docker.conf to point access.log to /dev/null/, which effectively prevents it from being picked up by the log driver
 RUN sed -i 's/access.log = .*/access.log = \/dev\/null/' /usr/local/etc/php-fpm.d/docker.conf
 
+# adds an easily accessible override config for php-fpm's pm.max_children value
+# the base image sets this value at 5, and the default value in the override matches that
+# if an instance of Materia receives moderate traffic, this value will likely need to be raised
+# the file is renamed to zzz-materia.conf to ensure it is loaded last, a zz-docker.conf will already be present in the php-fpm.d directory
+COPY --chown=www-data:www-data ./docker/config/php/materia.www.conf /usr/local/etc/php-fpm.d/zzz-materia.conf
+
 WORKDIR /var/www/html
 
 # =====================================================================================================


### PR DESCRIPTION
Resolves #1592. This adds a php-fpm configuration file to `docker/config/php` that is loaded into the `materia-app` image as part of the Dockerfile. The config overrides the `pm.max_children` default value (5) with a new value of your choosing. This file can alternatively be loaded into a container as a volume in a compose file, but by writing it into the image, it does not need to be expressly included in a custom compose file written for production purposes. Additionally, this method is compatible with UCF's deployment methods, whereas the compose file option would not be.

Testing this PR locally would mean destroying your local Materia containers and images and rerunning the `run_first.sh` script to ensure a new image is built from scratch. You will then have to `docker exec` into the app container and ensure the `zzz-materia.conf` file is written to the `/usr/local/etc/php-fpm.d/` directory.

To test non-destructively, you can add this to the base compose file's`app` definition:
```
volumes:
      - ./config/php/materia.www.conf:/usr/local/etc/php-fpm.d/zzz-materia.conf
```

To check the current number of `php-fpm` child processes running and their memory usage, the following command should work:

```
ps -eo pid,user,comm,rss | grep '[p]hp-fpm'
```