### PR TITLE
Added retry: false to react queries with error states

### DIFF
--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -12,7 +12,8 @@ const Header = ({
 	const { data: verified} = useQuery({
 		queryKey: 'isLoggedIn',
 		queryFn: apiAuthorVerify,
-		staleTime: Infinity
+		staleTime: Infinity,
+		retry: false
 	})
 	const { data: user, isLoading: userLoading} = useQuery({
 		queryKey: 'user',

--- a/src/components/my-widgets-collaborate-dialog.jsx
+++ b/src/components/my-widgets-collaborate-dialog.jsx
@@ -36,6 +36,7 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 		queryFn: () => apiGetUsers(Array.from(otherUserPerms.keys())),
 		staleTime: Infinity,
 		placeholderData: {},
+		retry: false,
 		onSuccess: (data) => {
 			setCollabUsers({...collabUsers, ...data})
 		},

--- a/src/components/my-widgets-page.jsx
+++ b/src/components/my-widgets-page.jsx
@@ -58,6 +58,7 @@ const MyWidgetsPage = () => {
 		queryKey: 'user',
 		queryFn: apiGetUser,
 		staleTime: Infinity,
+		retry: false,
 		onError: (err) => {
 			if (err.message == "Invalid Login")
 			{
@@ -80,6 +81,7 @@ const MyWidgetsPage = () => {
 		enabled: !!state.selectedInst && !!state.selectedInst.id && state.selectedInst?.id !== undefined,
 		placeholderData: null,
 		staleTime: Infinity,
+		retry: false,
 		onError: (err) => {
 			if (err.message == "Invalid Login") {
 				setInvalidLogin(true)

--- a/src/components/my-widgets-score-semester-individual.jsx
+++ b/src/components/my-widgets-score-semester-individual.jsx
@@ -38,6 +38,7 @@ const MyWidgetScoreSemesterIndividual = ({ semester, instId, setInvalidLogin }) 
 			enabled: !!instId && !!semester && !!semester.term && !!semester.year,
 			placeholderData: [],
 			refetchOnWindowFocus: false,
+			retry: false,
 			onSuccess: (result) => {
 				if (page <= result?.total_num_pages) setPage(page + 1)
 				if (result && result.pagination) {

--- a/src/components/my-widgets-score-semester-storage.jsx
+++ b/src/components/my-widgets-score-semester-storage.jsx
@@ -36,6 +36,7 @@ const MyWidgetScoreSemesterStorage = ({semester, instId, setInvalidLogin}) => {
 		enabled: !!instId,
 		staleTime: Infinity,
 		placeholderData: {},
+		retry: false,
 		onError: (err) => {
 			if (err.message == "Invalid Login") {
 				setInvalidLogin(true);

--- a/src/components/my-widgets-scores.jsx
+++ b/src/components/my-widgets-scores.jsx
@@ -20,6 +20,7 @@ const MyWidgetsScores = ({inst, beardMode, setInvalidLogin}) => {
 		enabled: !!inst && !!inst.id,
 		staleTime: Infinity,
 		placeholderData: [],
+		retry: false,
 		onError: (err) => {
 			if (err.message == "Invalid Login") {
 				setInvalidLogin(true);

--- a/src/components/my-widgets-selected-instance.jsx
+++ b/src/components/my-widgets-selected-instance.jsx
@@ -80,6 +80,7 @@ const MyWidgetSelectedInstance = ({
 		placeholderData: null,
 		enabled: !!inst.id,
 		staleTime: Infinity,
+		retry: false,
 		onError: (err) => {
 			if (err.message == "Invalid Login")
 			{

--- a/src/components/my-widgets-settings-dialog.jsx
+++ b/src/components/my-widgets-settings-dialog.jsx
@@ -84,6 +84,7 @@ const MyWidgetsSettingsDialog = ({ onClose, inst, currentUser, otherUserPerms, o
 		placeholderData: {},
 		enabled: !!otherUserPerms && Array.from(otherUserPerms.keys())?.length > 0,
 		staleTime: Infinity,
+		retry: false,
 		onError: (err) => {
 			console.error(`Error: ${err.message}`);
 			if (err.message == "Invalid Login") {

--- a/src/components/notifications.jsx
+++ b/src/components/notifications.jsx
@@ -5,17 +5,17 @@ import useDeleteNotification from './hooks/useDeleteNotification'
 import setUserInstancePerms from './hooks/useSetUserInstancePerms'
 
 const Notifications = (user) => {
-    const [navOpen, setNavOpen] = useState(false);
-    const [showDeleteBtn, setShowDeleteBtn] = useState(-1);
-    const deleteNotification = useDeleteNotification()
-    const queryClient = useQueryClient()
-    const setUserPerms = setUserInstancePerms()
-    const numNotifications = useRef(0);
-    const [errorMsg, setErrorMsg] = useState({
-        notif_id: '',
-        msg: ''
-    });
-    let modalRef = useRef();
+	const [navOpen, setNavOpen] = useState(false);
+	const [showDeleteBtn, setShowDeleteBtn] = useState(-1);
+	const deleteNotification = useDeleteNotification()
+	const queryClient = useQueryClient()
+	const setUserPerms = setUserInstancePerms()
+	const numNotifications = useRef(0);
+	const [errorMsg, setErrorMsg] = useState({
+		notif_id: '',
+		msg: ''
+	});
+	let modalRef = useRef();
 
 	const { data: notifications} = useQuery({
 		queryKey: 'notifications',
@@ -24,230 +24,231 @@ const Notifications = (user) => {
 		refetchOnMount: false,
 		refetchOnWindowFocus: true,
 		queryFn: apiGetNotifications,
-        staleTime: Infinity,
-        onSuccess: (data) => {
-            numNotifications.current = 0;
-            if (data && data.length > 0) data.forEach(element => {
-                if (!element.remove) numNotifications.current++;
-            });
-        },
-        onError: (err) => {
-            if (err.message == "Invalid Login") {
-                window.location.href = '/users/login'
-            } else {
-                console.error(err)
-            }
-        }
-    })
+		staleTime: Infinity,
+		retry: false,
+		onSuccess: (data) => {
+			numNotifications.current = 0;
+			if (data && data.length > 0) data.forEach(element => {
+				if (!element.remove) numNotifications.current++;
+			});
+		},
+		onError: (err) => {
+			if (err.message == "Invalid Login") {
+				window.location.href = '/users/login'
+			} else {
+				console.error(err)
+			}
+		}
+	})
 
-    // Close notification modal if user clicks outside of it
-    useEffect(() => {
-        if (navOpen)
-        {
-            const checkIfClickedOutsideModal = e => {
-                if (modalRef.current && !modalRef.current.contains(e.target) && !e.target.className.includes("noticeClose"))
-                {
-                    setNavOpen(false);
-                }
-            }
-            document.addEventListener("click", checkIfClickedOutsideModal);
+	// Close notification modal if user clicks outside of it
+	useEffect(() => {
+		if (navOpen)
+		{
+			const checkIfClickedOutsideModal = e => {
+				if (modalRef.current && !modalRef.current.contains(e.target) && !e.target.className.includes("noticeClose"))
+				{
+					setNavOpen(false);
+				}
+			}
+			document.addEventListener("click", checkIfClickedOutsideModal);
 
-            return () => {
-                document.removeEventListener("click", checkIfClickedOutsideModal);
-            }
-        }
-    }, [navOpen])
+			return () => {
+				document.removeEventListener("click", checkIfClickedOutsideModal);
+			}
+		}
+	}, [navOpen])
 
-    const toggleNavOpen = () =>
-    {
-        setNavOpen(!navOpen);
-    }
-    // Sets the index of the hovered notification
-    // Shows delete button on hover
-    const showDeleteButton = (index) =>
-    {
-        setShowDeleteBtn(index);
-    }
-    const hideDeleteButton = () =>
-    {
-        setShowDeleteBtn(-1);
-    }
+	const toggleNavOpen = () =>
+	{
+		setNavOpen(!navOpen);
+	}
+	// Sets the index of the hovered notification
+	// Shows delete button on hover
+	const showDeleteButton = (index) =>
+	{
+		setShowDeleteBtn(index);
+	}
+	const hideDeleteButton = () =>
+	{
+		setShowDeleteBtn(-1);
+	}
 
-    const removeNotification = (index, id = null) => {
-        let notif = null;
-        if (index >= 0) notif = notifications[index];
-        if (id == null) id = notif.id;
+	const removeNotification = (index, id = null) => {
+		let notif = null;
+		if (index >= 0) notif = notifications[index];
+		if (id == null) id = notif.id;
 
-        deleteNotification.mutate({
-            notifId: id,
-            deleteAll: false,
-            successFunc: () => {
-                Object.keys(notifications).forEach((key, index) => {
-                    if (notifications[key].id == id)
-                    {
-                        notifications[key].remove = true;
-                        numNotifications.current--;
-                        return;
-                    }
-                })
-            },
-            errorFunc: (err) => {
-                setErrorMsg({notif_id: id, msg: 'Action failed.'});
-            }
-        });
-    }
+		deleteNotification.mutate({
+			notifId: id,
+			deleteAll: false,
+			successFunc: () => {
+				Object.keys(notifications).forEach((key, index) => {
+					if (notifications[key].id == id)
+					{
+						notifications[key].remove = true;
+						numNotifications.current--;
+						return;
+					}
+				})
+			},
+			errorFunc: (err) => {
+				setErrorMsg({notif_id: id, msg: 'Action failed.'});
+			}
+		});
+	}
 
-    const removeAllNotifications = () => {
-        deleteNotification.mutate({
-            notifId: '',
-            deleteAll: true,
-            successFunc: () => {},
-            errorFunc: (err) => {}
-        });
-    }
+	const removeAllNotifications = () => {
+		deleteNotification.mutate({
+			notifId: '',
+			deleteAll: true,
+			successFunc: () => {},
+			errorFunc: (err) => {}
+		});
+	}
 
-    const onChangeAccessLevel = (notif, access) => {
-        if (access != "")
-        {
-            document.getElementById(notif.id + '_action_button').className = "action_button notification_action enabled";
-        }
-    }
+	const onChangeAccessLevel = (notif, access) => {
+		if (access != "")
+		{
+			document.getElementById(notif.id + '_action_button').className = "action_button notification_action enabled";
+		}
+	}
 
-    const onClickGrantAccess = (notif) => {
-        let accessLevel = document.getElementById(notif.id + '-access-level').value;
+	const onClickGrantAccess = (notif) => {
+		let accessLevel = document.getElementById(notif.id + '-access-level').value;
 
-        if (accessLevel == "")
-        {
-            return;
-        }
+		if (accessLevel == "")
+		{
+			return;
+		}
 
-        const expireTime = null;
+		const expireTime = null;
 
-        const userPerms = [{
-            user_id: notif.from_id,
-            expiration: expireTime,
-            perms: {
-                [accessLevel]: true
-            },
-        }]
-        setUserPerms.mutate({
-            instId: notif.item_id,
-            permsObj: userPerms,
-            successFunc: (data) => {
-                // Redirect to widget
-                if (!window.location.pathname.includes('my-widgets'))
-                {
-                    // No idea why this works
-                    // But setting hash after setting pathname would set the hash first and then the pathname in URL
-                    window.location.hash = notif.item_id + '-collab';
-                    window.location.pathname = '/my-widgets'
-                }
-                else
-                {
-                    queryClient.invalidateQueries(['user-perms', notif.item_id])
-                    window.location.hash = notif.item_id + '-collab';
-                }
+		const userPerms = [{
+			user_id: notif.from_id,
+			expiration: expireTime,
+			perms: {
+				[accessLevel]: true
+			},
+		}]
+		setUserPerms.mutate({
+			instId: notif.item_id,
+			permsObj: userPerms,
+			successFunc: (data) => {
+				// Redirect to widget
+				if (!window.location.pathname.includes('my-widgets'))
+				{
+					// No idea why this works
+					// But setting hash after setting pathname would set the hash first and then the pathname in URL
+					window.location.hash = notif.item_id + '-collab';
+					window.location.pathname = '/my-widgets'
+				}
+				else
+				{
+					queryClient.invalidateQueries(['user-perms', notif.item_id])
+					window.location.hash = notif.item_id + '-collab';
+				}
 
-                setErrorMsg({notif_id: notif.id, msg: ''});
+				setErrorMsg({notif_id: notif.id, msg: ''});
 
-                removeNotification(-1, notif.id);
+				removeNotification(-1, notif.id);
 
-                // Close notifications
-                setNavOpen(false)
-            },
-            errorFunc: (err) => {
-                setErrorMsg({notif_id: notif.id, msg: 'Action failed.'})
-            }
-        })
+				// Close notifications
+				setNavOpen(false)
+			},
+			errorFunc: (err) => {
+				setErrorMsg({notif_id: notif.id, msg: 'Action failed.'})
+			}
+		})
 
 
-    }
+	}
 
-    let render = null;
-    let notificationElements = null;
-    let notificationIcon = null;
+	let render = null;
+	let notificationElements = null;
+	let notificationIcon = null;
 
-    if (notifications?.length > 0) {
-        notificationElements = []
-        for (let index = notifications.length - 1; index >= 0; index--)
-        {
-            const notification = notifications[index];
-            // If notification was deleted don't show
-            if (notification.remove) continue;
+	if (notifications?.length > 0) {
+		notificationElements = []
+		for (let index = notifications.length - 1; index >= 0; index--)
+		{
+			const notification = notifications[index];
+			// If notification was deleted don't show
+			if (notification.remove) continue;
 
-            let actionButton = null;
-            let grantAccessDropdown = null;
-            if (notification.action == "access_request")
-            {
-                grantAccessDropdown = <div>
-                <h3 className="grantAccessTitle">Grant Access</h3>
-                    <select name="access-level" id={notification.id + "-access-level"} defaultValue="" onChange={(value) => onChangeAccessLevel(notification, value)}>
-                        <option value="30">Full</option>
-                        <option value="1">View Scores</option>
-                        <option value="" disabled hidden>Select Access Level</option>
-                    </select>
-                </div>
-                actionButton =  <button className="action_button notification_action" id={notification.id + "_action_button"} onClick={() => onClickGrantAccess(notification)}>Grant Access</button>
-            }
-            let createdAt = new Date(0);
-            createdAt.setUTCSeconds(notification.created_at)
-            let notifRow = <div className={`notice${notification.deleted ? 'deleted' : ''}`}
-                key={notification.id}
-                onMouseEnter={() => showDeleteButton(index)}
-                onMouseLeave={hideDeleteButton}
-                >
-                <img className='senderAvatar' src={notification.avatar} />
-                <div className='notice_right_side'>
-                    <div dangerouslySetInnerHTML={{__html: `<p class='subject'>${notification.subject}</p>`}}></div>
-                    { grantAccessDropdown }
-                    { actionButton }
-                    <p className="notif-date">Sent on {createdAt.toLocaleString()}</p>
-                </div>
-                <img src="/img/icon-cancel.svg"
-                    className={`noticeClose ${showDeleteBtn == index ? 'show' : ''}`}
-                    onClick={() => {removeNotification(index)}}
-                />
-                <p className='notif-error'>{errorMsg.notif_id == notification.id ? errorMsg.msg : ''}</p>
-            </div>
+			let actionButton = null;
+			let grantAccessDropdown = null;
+			if (notification.action == "access_request")
+			{
+				grantAccessDropdown = <div>
+				<h3 className="grantAccessTitle">Grant Access</h3>
+					<select name="access-level" id={notification.id + "-access-level"} defaultValue="" onChange={(value) => onChangeAccessLevel(notification, value)}>
+						<option value="30">Full</option>
+						<option value="1">View Scores</option>
+						<option value="" disabled hidden>Select Access Level</option>
+					</select>
+				</div>
+				actionButton =  <button className="action_button notification_action" id={notification.id + "_action_button"} onClick={() => onClickGrantAccess(notification)}>Grant Access</button>
+			}
+			let createdAt = new Date(0);
+			createdAt.setUTCSeconds(notification.created_at)
+			let notifRow = <div className={`notice${notification.deleted ? 'deleted' : ''}`}
+				key={notification.id}
+				onMouseEnter={() => showDeleteButton(index)}
+				onMouseLeave={hideDeleteButton}
+				>
+				<img className='senderAvatar' src={notification.avatar} />
+				<div className='notice_right_side'>
+					<div dangerouslySetInnerHTML={{__html: `<p class='subject'>${notification.subject}</p>`}}></div>
+					{ grantAccessDropdown }
+					{ actionButton }
+					<p className="notif-date">Sent on {createdAt.toLocaleString()}</p>
+				</div>
+				<img src="/img/icon-cancel.svg"
+					className={`noticeClose ${showDeleteBtn == index ? 'show' : ''}`}
+					onClick={() => {removeNotification(index)}}
+				/>
+				<p className='notif-error'>{errorMsg.notif_id == notification.id ? errorMsg.msg : ''}</p>
+			</div>
 
-            notificationIcon =
-            <button id='notifications_link' className='notEmpty'
-                data-notifications={numNotifications.current}
-                onClick={() => toggleNavOpen()}></button>
+			notificationIcon =
+			<button id='notifications_link' className='notEmpty'
+				data-notifications={numNotifications.current}
+				onClick={() => toggleNavOpen()}></button>
 
-            notificationElements.push(notifRow)
-        }
+			notificationElements.push(notifRow)
+		}
 
-        // In the case that some notifications were removed, we don't want to render the empty notificationElements
-        if (notificationElements.length > 0)
-        {
-            render = (
-                <div className="notifContainer">
-                    { notificationIcon }
-                    { navOpen ?
-                        <div id='notices' ref={modalRef}>
-                            <h2>Messages:</h2>
-                            { notificationElements }
-                            <a id="removeAllNotifications" onClick={()=>removeAllNotifications()}>Remove all Notifications</a>
-                        </div>
-                    : <></> }
-                </div>
-            )
-        }
-    }
-    else
-    {
-        render = null;
+		// In the case that some notifications were removed, we don't want to render the empty notificationElements
+		if (notificationElements.length > 0)
+		{
+			render = (
+				<div className="notifContainer">
+					{ notificationIcon }
+					{ navOpen ?
+						<div id='notices' ref={modalRef}>
+							<h2>Messages:</h2>
+							{ notificationElements }
+							<a id="removeAllNotifications" onClick={()=>removeAllNotifications()}>Remove all Notifications</a>
+						</div>
+					: <></> }
+				</div>
+			)
+		}
+	}
+	else
+	{
+		render = null;
 
-        // Keeping this here in case the empty notification icon gets used
-        notificationElements = <h2>You have no messages!</h2>
+		// Keeping this here in case the empty notification icon gets used
+		notificationElements = <h2>You have no messages!</h2>
 
-        notificationIcon =
-        <button id='notifications_link'
-            onClick={() => toggleNavOpen()}></button>
-    }
+		notificationIcon =
+		<button id='notifications_link'
+			onClick={() => toggleNavOpen()}></button>
+	}
 
-    return render;
+	return render;
 }
 
 export default Notifications

--- a/src/components/profile-page.jsx
+++ b/src/components/profile-page.jsx
@@ -21,6 +21,7 @@ const ProfilePage = () => {
 		queryKey: 'user',
 		queryFn: apiGetUser,
 		staleTime: Infinity,
+		retry: false,
 		onError: (err) => {
 			if (err.message == "Invalid Login") {
 				setAlertDialog({

--- a/src/components/question-history.jsx
+++ b/src/components/question-history.jsx
@@ -20,6 +20,7 @@ const QuestionHistory = () => {
 		queryFn: () => apiGetQuestionSetHistory(instId),
 		enabled: !!instId,
 		staleTime: Infinity,
+		retry: false,
 		onError: (err) => {
 			setError("Error fetching question set history.")
 			console.error(err.cause)

--- a/src/components/scores.jsx
+++ b/src/components/scores.jsx
@@ -76,6 +76,7 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 		enabled: false, // enabled is set to false so the query can be manually called with the refetch function
 		staleTime: Infinity,
 		refetchOnWindowFocus: false,
+		retry: false,
 		onSuccess: (result) => {
 			_populateScores(result.scores)
 			setAttemptsLeft(result.attempts_left)
@@ -99,6 +100,7 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 		enabled: false, // enabled is set to false so the query can be manually called with the refetch function
 		staleTime: Infinity,
 		refetchOnWindowFocus: false,
+		retry: false,
 		onSuccess: (result) => {
 			_populateScores(result)
 		},
@@ -138,6 +140,7 @@ const Scores = ({ inst_id, play_id, single_id, send_token, isEmbedded, isPreview
 		queryFn: () => apiGetScoreDistribution(inst_id),
 		enabled: false,
 		staleTime: Infinity,
+		retry: false,
 		onSuccess: (data) => {
 			_sendToWidget('scoreDistribution', [data])
 		},

--- a/src/components/settings-page.jsx
+++ b/src/components/settings-page.jsx
@@ -21,6 +21,7 @@ const SettingsPage = () => {
 		queryKey: 'user',
 		queryFn: apiGetUser,
 		staleTime: Infinity,
+		retry: false,
 		onError: (err) => {
 			if (err.message == "Invalid Login") {
 				setAlertDialog({

--- a/src/components/support-page.jsx
+++ b/src/components/support-page.jsx
@@ -15,6 +15,7 @@ const SupportPage = () => {
 		queryKey: 'user',
 		queryFn: apiGetUser,
 		staleTime: Infinity,
+		retry: false,
 		onError: (err) => {
 			if (err.message == "Invalid Login") {
 				window.location.href = '/login'
@@ -29,6 +30,7 @@ const SupportPage = () => {
 		queryFn: () => apiSearchInstances(widgetHash),
 		enabled: widgetHash != undefined && widgetHash != selectedInstance?.id,
 		staleTime: Infinity,
+		retry: false,
 		onError: (err) => {
 			if (err.message == "Invalid Login") {
 				window.location.href = '/login'

--- a/src/components/support-selected-instance.jsx
+++ b/src/components/support-selected-instance.jsx
@@ -76,6 +76,7 @@ const SupportSelectedInstance = ({inst, currentUser, onCopySuccess, embed = fals
 		enabled: !!inst && inst.id !== undefined,
 		placeholderData: null,
 		staleTime: Infinity,
+		retry: false,
 		onError: (err) => {
 			if (err.message == "Invalid Login") {
 				setInvalidLogin(true)

--- a/src/components/user-admin-page.jsx
+++ b/src/components/user-admin-page.jsx
@@ -14,6 +14,7 @@ const UserAdminPage = () => {
 		queryKey: 'user',
 		queryFn: apiGetUser,
 		staleTime: Infinity,
+		retry: false,
 		onError: (err) => {
 			if (err.message == "Invalid Login") {
 				window.location.href = '/login'
@@ -29,6 +30,7 @@ const UserAdminPage = () => {
 		enabled: userHash != undefined && userHash != selectedUser?.id,
 		placeholderData: null,
 		staleTime: Infinity,
+		retry: false,
 		onError: (err) => {
 			if (err.message == "Invalid Login") {
 				window.location.href = '/login'

--- a/src/components/user-admin-selected.jsx
+++ b/src/components/user-admin-selected.jsx
@@ -14,6 +14,7 @@ const UserAdminSelected = ({selectedUser, currentUser, onReturn}) => {
 		queryFn: () => apiGetInstancesForUser(updatedUser.id),
 		placeholderData: null,
 		staleTime: Infinity,
+		retry: false,
 		onError: (err) => {
 			if (err.message == "Invalid Login") {
 				window.location.href = '/login'

--- a/src/components/widget-admin-page.jsx
+++ b/src/components/widget-admin-page.jsx
@@ -14,6 +14,7 @@ const WidgetAdminPage = () => {
 		queryKey: ['widgets'],
 		queryFn: apiGetWidgetsAdmin,
 		staleTime: Infinity,
+		retry: false,
 		onSuccess: (widgetData) => {
 			widgetData.forEach((w) => {
 				w.icon = iconUrl('/widget/', w.dir, 60)

--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -71,6 +71,7 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		queryFn: () => apiGetWidget(widgetId),
 		enabled: !!widgetId,
 		staleTime: Infinity,
+		retry: false,
 		onSuccess: (info) => {
 			if (info) {
 				setInstance({ ...instance, widget: info })
@@ -88,6 +89,7 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		queryFn: () => apiGetWidgetInstance(instId),
 		enabled: !!instId,
 		staleTime: Infinity,
+		retry: false,
 		onSuccess: (data) => {
 			// this value will include a qset that's always empty
 			// it will override the instance's qset property even if it's already set
@@ -108,6 +110,7 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		staleTime: Infinity,
 		placeholderData: null,
 		enabled: !!instIdRef.current, // requires instance state object to be prepopulated
+		retry: false,
 		onSuccess: (data) => {
 			if (data) {
 				setCreatorState({...creatorState, invalid: false})
@@ -126,6 +129,7 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		queryFn: () => apiCanBePublishedByCurrentUser(instance.widget?.id),
 		enabled: instance?.widget !== null,
 		staleTime: Infinity,
+		retry: false,
 		onSuccess: (success) => {
 			if (!success && !instance.is_draft) {
 				onInitFail('Widget type can not be edited by students after publishing.')
@@ -142,6 +146,7 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		staleTime: 30000,
 		refetchInterval: 30000,
 		enabled: creatorState.heartbeatEnabled,
+		retry: 1,
 		onError: (error) => {
 			onInitFail(error)
 		},
@@ -160,6 +165,7 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		queryFn: () => apiGetWidgetLock(instance.id),
 		enabled: !!instance.id,
 		staleTime: Infinity,
+		retry: false,
 		onSuccess: (success) => {
 			if (!success) {
 				onInitFail('Someone else is editing this widget, you will be able to edit after they finish.')

--- a/src/components/widget-player.jsx
+++ b/src/components/widget-player.jsx
@@ -123,6 +123,7 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 		queryFn: () => apiGetWidgetInstance(instanceId),
 		enabled: instanceId !== null,
 		staleTime: Infinity,
+		retry: false,
 		onError: (err) => {
 			if (err.message == "Invalid Login") {
 				setAlert({
@@ -148,6 +149,7 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 		queryFn: () => apiGetQuestionSet(instanceId, playId),
 		staleTime: Infinity,
 		placeholderData: null,
+		retry: false,
 		onError: (err) => {
 			if (err.message == "Invalid Login") {
 				setAlert({
@@ -174,6 +176,7 @@ const WidgetPlayer = ({instanceId, playId, minHeight='', minWidth='',showFooter=
 		staleTime: Infinity,
 		refetchInterval: HEARTBEAT_INTERVAL,
 		enabled: !!playId && heartbeatActive,
+		retry: 1,
 		onError: (err) => {
 			if (err.message == "Invalid Login") {
 				setAlert({


### PR DESCRIPTION
Like the title says, adds `retry: false` to all instances of `useQuery` with a provided `onError` parameter. These queries have fallback behavior for error states, but the built-in retry mechanism for react query meant that error states were delayed by as much as 10-15 seconds as react query attempts its default 3 retries before failing. While useful in principle, the delays to error states feels real bad and could cause issues where a user continues to try interacting with the page when the server has already kicked them out.