### PR TITLE
Improves widget pre-embed views

### DIFF
--- a/src/components/closed.jsx
+++ b/src/components/closed.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Header from './header'
 import Summary from './widget-summary'
 import './login-page.scss'
+import EmbedFooter from './widget-embed-footer';
 
 const Closed = () => {
 
@@ -45,6 +46,7 @@ const Closed = () => {
 					<Summary />
 					<h3>{ state.summary }</h3>
 					<p>{ state.description }</p>
+					<EmbedFooter/>
 				</section>
 			</div>
 		</>

--- a/src/components/embedded-only.jsx
+++ b/src/components/embedded-only.jsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import Summary from './widget-summary'
+import EmbedFooter from './widget-embed-footer';
 
 const EmbeddedOnly = () => {
   return (
-    <div className="container widget">
-    	<section className="page">
-    		<Summary/>
+	<div className="container widget">
+		<section className="page">
+			<Summary/>
 
-    		<div className="detail icon-offset">
-    			<h2 className="unavailable-text">Not Playable Here</h2>
-    			<span className="unavailable-subtext">Your instructor has not made this widget available outside of the LMS.</span>
-    		</div>
-    	</section>
-    </div>
+			<div className="detail icon-offset">
+				<h2 className="unavailable-text">Not Playable Here</h2>
+				<span className="unavailable-subtext">Your instructor has not made this widget available outside of the LMS.</span>
+			</div>
+
+			<EmbedFooter/>
+		</section>
+	</div>
   )
 }
 

--- a/src/components/login-page.jsx
+++ b/src/components/login-page.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import Header from './header'
 import Summary from './widget-summary'
 import './login-page.scss'
+import EmbedFooter from './widget-embed-footer'
 
 const LoginPage = () => {
 
@@ -107,6 +108,7 @@ const LoginPage = () => {
 							: '' }
 						</form>
 					</div>
+					{ state.context && state.context == 'widget' ? <EmbedFooter /> : ''}
 				</section>
 			</div>
 		</>

--- a/src/components/login-page.scss
+++ b/src/components/login-page.scss
@@ -3,5 +3,5 @@
 
 span.subtitle {
 	font-size: .7em;
-	font-weight: 300;
+	font-weight: 400;
 }

--- a/src/components/no-attempts.jsx
+++ b/src/components/no-attempts.jsx
@@ -1,21 +1,22 @@
 import React, { useState, useEffect} from 'react'
 import Summary from './widget-summary'
 import Header from './header'
+import EmbedFooter from './widget-embed-footer'
 
 const NoAttempts = () => {
-  const [attempts, setAttempts] = useState(null)
-  const [scoresPath, setScoresPath] = useState(null)
+	const [attempts, setAttempts] = useState(null)
+	const [scoresPath, setScoresPath] = useState(null)
 
-  useEffect(() => {
-    waitForWindow().then(() => {
-      const scoresPath = `/scores${window.IS_EMBEDDED ? '/embed' : ''}/${window.WIDGET_ID}`;
+	useEffect(() => {
+	waitForWindow().then(() => {
+	const scoresPath = `/scores${window.IS_EMBEDDED ? '/embed' : ''}/${window.WIDGET_ID}`;
 
-      setScoresPath(scoresPath);
-      setAttempts(window.ATTEMPTS)
-    })
-  }, [])
+	setScoresPath(scoresPath);
+	setAttempts(window.ATTEMPTS)
+	})
+}, [])
 
-  const waitForWindow = async () => {
+const waitForWindow = async () => {
 		while(!window.hasOwnProperty('WIDGET_ID')
 		&& !window.hasOwnProperty('IS_EMBEDDED')
 		&& !window.hasOwnProperty('ATTEMPTS')) {
@@ -23,31 +24,33 @@ const NoAttempts = () => {
 		}
 	}
 
-  let bodyRender = null
-  if (!!attempts) {
-    bodyRender = (
-      <div className={"container widget"}>
-      	<section className="attempts page">
-      		<Summary/>
+	let bodyRender = null
+	if (!!attempts) {
+	bodyRender = (
+	<div className={"container widget"}>
+		<section className="attempts page">
+			<Summary/>
 
-      		<div className="detail icon-offset">
-      			<h2 className="unavailable-text">No remaining attempts</h2>
-      			<span className="unavailable-subtext">You've used all { attempts } available attempts.</span>
-      			<p>
-      				<a href={ scoresPath }>Review previous scores</a>
-      			</p>
-      		</div>
-      	</section>
-      </div>
-    )
-  }
+			<div className="detail icon-offset">
+				<h2 className="unavailable-text">No remaining attempts</h2>
+				<span className="unavailable-subtext">You've used all { attempts } available attempts.</span>
+				<p>
+					<a href={ scoresPath }>Review previous scores</a>
+				</p>
+			</div>
 
-  return (
-    <>
-      <Header />
-      { bodyRender }
-    </>
-  )
+			<EmbedFooter/>
+		</section>
+	</div>
+	)
+}
+
+return (
+	<>
+		<Header />
+		{ bodyRender }
+	</>
+)
 }
 
 export default NoAttempts

--- a/src/components/pre-embed-common-styles.scss
+++ b/src/components/pre-embed-common-styles.scss
@@ -75,6 +75,17 @@ body {
 			text-align: center;
 			clear: both;
 
+			&.pre-embed {
+				padding: 2em 0;
+
+				background: #f3f3f3;
+				border-radius: 4px;
+
+				.action_button {
+					margin: 24px;
+				}
+			}
+
 			h2 {
 				font-size: 18pt;
 			}
@@ -102,11 +113,22 @@ body {
 
 		.widget_info {
 			position: relative;
+			display: flex;
+			justify-content: flex-start;
+			align-items: center;
+			gap: 1em;
 			min-height: 122px;
-			padding-left: 110px;
+			width: calc(100% + 20px);
 
-			list-style: none;
+			top: -15px;
+			left: -10px;
 
+			border-top-left-radius: 4px;
+			border-top-right-radius: 4px;
+			
+			background: #0093e7;
+			color: #fff;
+			
 			li {
 				display: block;
 				margin-right: 10px;
@@ -126,18 +148,7 @@ body {
 			}
 
 			.widget_icon {
-				position: absolute;
-				top: 0;
-				left: -25px;
-				background: #0093e7;
-				width: 92px;
-				height: 92px;
-				padding: 15px;
-				text-align: center;
-				color: #fff;
-				font-size: 10px;
-				line-height: 13px;
-				box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.4);
+				padding-left: 15px;
 
 				img {
 					width: 92px;
@@ -149,6 +160,7 @@ body {
 		}
 
 		ul.widget_about {
+			margin: 0;
 			padding: 0;
 			list-style-type: none;
 
@@ -166,6 +178,33 @@ body {
 
 				line-height: 37px;
 				text-align: left;
+			}
+		}
+
+		.widget-embed-footer {
+			position: absolute;
+			bottom: 5px;
+
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+
+			width: calc(100% - 20px);
+
+			font-size: 0.7em;
+			font-weight: 400;
+
+			color: #5e5e5e;
+
+			a {
+				&.materia-logo {
+	
+					img {
+						width: auto;
+						height: 15px;
+						margin-top: 1px;
+					}
+				}
 			}
 		}
 

--- a/src/components/pre-embed-placeholder.jsx
+++ b/src/components/pre-embed-placeholder.jsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect} from 'react'
 import Summary from './widget-summary'
+import EmbedFooter from './widget-embed-footer'
 
 import './pre-embed-common-styles.scss'
+
 
 const PreEmbedPlaceholder = () => {
 
@@ -27,9 +29,10 @@ const PreEmbedPlaceholder = () => {
 			<div className="container widget">
 				<section className="page">
 					<Summary/>
-					<div className="detail icon-offset">
-						<a className="action_button" href={`/${context}/${instId}`}>Play</a>
+					<div className="detail pre-embed">
+						<a className="action_button" href={`/${context}/${instId}`}>Play Widget</a>
 					</div>
+					<EmbedFooter/>
 				</section>
 			</div>
 		)

--- a/src/components/widget-embed-footer.jsx
+++ b/src/components/widget-embed-footer.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+const EmbedFooter = () => {
+
+	return (
+		<section className='widget-embed-footer'>
+			<a className="materia-logo" href={window.BASE_URL} target="_blank"><img src="/img/materia-logo-thin.svg" alt="materia logo" /></a>
+			<span>
+				Content embedded from Materia. Need a hand? View <a className='inline-link' href={`${window.BASE_URL}/help#students`} target='_blank'>support options</a>.
+			</span>
+		</section>
+	)
+}
+
+export default EmbedFooter


### PR DESCRIPTION
Resolves #1590. Adds updated styling and footer links to Materia as well as support resources.

<img width="644" alt="Screenshot 2024-07-24 at 1 26 40 PM" src="https://github.com/user-attachments/assets/a9ef0b0a-6494-4e2a-b41c-fbe7133c1911">

<img width="637" alt="Screenshot 2024-07-24 at 1 27 01 PM" src="https://github.com/user-attachments/assets/1a33f422-32be-4a28-b057-56bd6d087732">

Updated pre-embed views include:
- Disabled Autoplay (`?autoplay=false` included in play/embed URL)
- Login
- No Attempts
- Closed (when open/close time values are set)
- Embedded Only
