### PR TITLE
1600/save draft button

### DIFF
--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -455,6 +455,8 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 				})
 
 				setCreatorState({...creatorState, heartbeatEnabled: false})
+                //also update the text on the Save Draft Button
+                setCreatorState({ ...creatorState, saveText: 'Failed to save' })
 			} else {
 				setAlertDialog({
 					enabled: true,
@@ -463,6 +465,9 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 					fatal: false,
 					enableLoginButton: false
 				})
+                //also update the text on the Save Draft Button
+                setCreatorState({ ...creatorState, saveText: 'Failed to save' })
+
 			}
 		} else {
 			setAlertDialog({
@@ -472,6 +477,9 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 				fatal: false,
 				enableLoginButton: false
 			})
+            //also update the text on the Save Draft Button
+            setCreatorState({ ...creatorState, saveText: 'Failed to save' })
+
 		}
 	}
 

--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -39,7 +39,8 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		popupState: null,
 		returnUrl: null,
 		returnLocation: 'Widget Catalog',
-		directUploadMediaFile: null
+		directUploadMediaFile: null,
+        isTimeoutRunning: false
 	})
 
 	const [alertDialog, setAlertDialog] = useState({
@@ -295,6 +296,13 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		if (!!saveWidgetComplete) {
 			if (saveWidgetComplete == 'save') {
 				setCreatorState(creatorState => ({...creatorState, saveText: 'Draft Saved', saveStatus: 'idle'}))
+                if(!creatorState.isTimeoutRunning) {
+                    //this line is needed again or else the text will revert to 'Save Draft' immidietly
+                    setCreatorState({...creatorState, saveText: 'Draft Saved', saveStatus: 'idle', isTimeoutRunning: true})
+                    setTimeout( () => {
+                        setCreatorState( {...creatorState, saveText: 'Save Draft', isTimeoutRunning:false} )
+                    } , 5000) //text gets reverted after 5 seconds(format is millisecond)
+                }
 			}
 			else if (saveWidgetComplete == 'preview') {
 				setCreatorState(creatorState => ({...creatorState, saveStatus: 'idle'}))
@@ -469,6 +477,14 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
                 setCreatorState({ ...creatorState, saveText: 'Failed to save' })
 
 			}
+            if(!creatorState.isTimeoutRunning) {
+                setCreatorState({...creatorState, saveText: 'Failed to save', saveStatus: 'idle', isTimeoutRunning: true})
+                setTimeout( () => {
+                    setCreatorState( {...creatorState, saveText: 'Save Draft', isTimeoutRunning:false} )
+                } , 5000) //text gets reverted after 5 seconds(format is millisecond)
+            }
+
+
 		} else {
 			setAlertDialog({
 				enabled: true,
@@ -479,6 +495,14 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 			})
             //also update the text on the Save Draft Button
             setCreatorState({ ...creatorState, saveText: 'Failed to save' })
+            if(!creatorState.isTimeoutRunning) {
+                setCreatorState({...creatorState, saveText: 'Failed to save', saveStatus: 'idle', isTimeoutRunning: true})
+                setTimeout( () => {
+                    setCreatorState( {...creatorState, saveText: 'Save Draft', isTimeoutRunning:false} )
+                } , 5000) //text gets reverted after 5 seconds(format is millisecond)
+            }
+
+
 
 		}
 	}

--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -455,7 +455,7 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 				})
 
 				setCreatorState({...creatorState, heartbeatEnabled: false})
-                //also update the text on the Save Draft Button
+                //also update the text on the Save Draft Buttons
                 setCreatorState({ ...creatorState, saveText: 'Failed to save' })
 			} else {
 				setAlertDialog({

--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -40,7 +40,7 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		returnUrl: null,
 		returnLocation: 'Widget Catalog',
 		directUploadMediaFile: null,
-        isTimeoutRunning: false
+		isTimeoutRunning: false
 	})
 
 	const [alertDialog, setAlertDialog] = useState({
@@ -296,13 +296,9 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		if (!!saveWidgetComplete) {
 			if (saveWidgetComplete == 'save') {
 				setCreatorState(creatorState => ({...creatorState, saveText: 'Draft Saved', saveStatus: 'idle'}))
-                if(!creatorState.isTimeoutRunning) {
-                    //this line is needed again or else the text will revert to 'Save Draft' immidietly
-                    setCreatorState({...creatorState, saveText: 'Draft Saved', saveStatus: 'idle', isTimeoutRunning: true})
-                    setTimeout( () => {
-                        setCreatorState( {...creatorState, saveText: 'Save Draft', isTimeoutRunning:false} )
-                    } , 5000) //text gets reverted after 5 seconds(format is millisecond)
-                }
+				if(!creatorState.isTimeoutRunning) {
+					setCreatorState({...creatorState, saveText: 'Draft Saved', saveStatus: 'idle', isTimeoutRunning: true});
+				}
 			}
 			else if (saveWidgetComplete == 'preview') {
 				setCreatorState(creatorState => ({...creatorState, saveStatus: 'idle'}))
@@ -311,6 +307,21 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 			setSaveWidgetComplete(null)
 		}
 	},[saveWidgetComplete])
+
+	useEffect( () => {
+		if(creatorState.isTimeoutRunning) {
+			const timeoutID = setTimeout( () => {
+				setCreatorState( prevState => ({
+					...prevState,
+					saveText: 'Save Draft',
+					isTimeoutRunning: false
+				}));
+			}, 5000);
+
+			return () => clearTimeout(timeoutID);
+		}
+
+	}, [creatorState.isTimeoutRunning]);
 
 	/* =========== postMessage handlers =========== */
 
@@ -462,9 +473,13 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 					enableLoginButton: true
 				})
 
-				setCreatorState({...creatorState, heartbeatEnabled: false})
-                //also update the text on the Save Draft Buttons
-                setCreatorState({ ...creatorState, saveText: 'Failed to save' })
+				setCreatorState({
+					...creatorState,
+					heartbeatEnabled: false,
+					saveText: 'Failed to save',
+					saveStatus: 'idle',
+					isTimeoutRunning: true
+				});
 			} else {
 				setAlertDialog({
 					enabled: true,
@@ -473,17 +488,15 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 					fatal: false,
 					enableLoginButton: false
 				})
-                //also update the text on the Save Draft Button
-                setCreatorState({ ...creatorState, saveText: 'Failed to save' })
+				//also update the text on the Save Draft Button
+				setCreatorState({
+					...creatorState,
+					saveText: 'Failed to save',
+					saveStatus: 'idle',
+					isTimeoutRunning: true
+				});
 
 			}
-            if(!creatorState.isTimeoutRunning) {
-                setCreatorState({...creatorState, saveText: 'Failed to save', saveStatus: 'idle', isTimeoutRunning: true})
-                setTimeout( () => {
-                    setCreatorState( {...creatorState, saveText: 'Save Draft', isTimeoutRunning:false} )
-                } , 5000) //text gets reverted after 5 seconds(format is millisecond)
-            }
-
 
 		} else {
 			setAlertDialog({
@@ -493,16 +506,12 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 				fatal: false,
 				enableLoginButton: false
 			})
-            //also update the text on the Save Draft Button
-            setCreatorState({ ...creatorState, saveText: 'Failed to save' })
-            if(!creatorState.isTimeoutRunning) {
-                setCreatorState({...creatorState, saveText: 'Failed to save', saveStatus: 'idle', isTimeoutRunning: true})
-                setTimeout( () => {
-                    setCreatorState( {...creatorState, saveText: 'Save Draft', isTimeoutRunning:false} )
-                } , 5000) //text gets reverted after 5 seconds(format is millisecond)
-            }
-
-
+			setCreatorState({
+				...creatorState,
+				saveText: 'Failed to save',
+				saveStatus: 'idle',
+				isTimeoutRunning: true
+			});
 
 		}
 	}


### PR DESCRIPTION
In this PR, I addressed an issue where, after calling `Materia.CreatorCore.cancelSave(message)`, the text on the save draft button would remain as "Saving...," which could cause confusion for users. I added three lines of code to update the button text to "Failed to save" whenever the save action fails.

**Key Changes:**
The save draft button text now updates to "Failed to save" when `Materia.CreatorCore.cancelSave(message)` is triggered.

This provides better feedback to the user, making it clear that the save attempt was unsuccessful.
**Note: **The text will only update on widgets that call `Materia.CreatorCore.cancelSave(message)`. Widgets that do not call this function should be updated when the creator attempts to save an incomplete widget.

**Considerations:**
The text could be further improved to be more user-friendly or detailed, such as `"Error saving, please try again"` or `"Please try again."` If you prefer a more descriptive message, I can update this in a follow-up change.