### PR TITLE
checks the length of the title before saving(base: dev/10.3.0)

### DIFF
--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -384,18 +384,17 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 	}
 
 	const save = (instanceName, qset, version = 1) => {
-        //cancel saving of the widget if title is too long to prevent crashing
-        let titleLength = instanceName.length;
-        if(titleLength>100) {
-            setAlertDialog({
-                enabled: true,
-                title: 'Title too long', //the max length for title in my testing is 100
-                message: 'Title must be less than 100 characters',
-                fatal: false,
-                enableLoginButton: false
-            });
-            return;
-        }
+		//cancel saving of the widget if title is too long to prevent crashing
+		if(instanceName.length>100) {
+			setAlertDialog({
+				enabled: true,
+				title: 'Title too long', //the max length for title in my testing is 100
+				message: 'Title must be less than 100 characters',
+				fatal: false,
+				enableLoginButton: false
+			});
+			return false;
+		}
 		let newWidget = {
 			widget_id: widgetId,
 			name: instanceName,

--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -384,6 +384,18 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 	}
 
 	const save = (instanceName, qset, version = 1) => {
+        //cancel saving of the widget if title is too long to prevent crashing
+        let titleLength = instanceName.length;
+        if(titleLength>100) {
+            setAlertDialog({
+                enabled: true,
+                title: 'Title too long', //the max length for title in my testing is 100
+                message: 'Title must be less than 100 characters',
+                fatal: false,
+                enableLoginButton: false
+            });
+            return;
+        }
 		let newWidget = {
 			widget_id: widgetId,
 			name: instanceName,


### PR DESCRIPTION
For issue #1598 , if a creator enters in a title with a length of 101 characters or more it will return a 403 error. 

**Changes:**
In the `const save = (instanceName, qset, version = 1) => {` part of the code before it does anything I first get the length of `instanceName` and check if its greater than 100. If it is then I run the built in `setAlertDialog({` function and return early notifying to the creator that the title length is too long. 

