### PR TITLE
1595/instance filtering

### DIFF
--- a/src/components/checkbox-button.jsx
+++ b/src/components/checkbox-button.jsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import './checkbox-button.scss';
+
+const CheckboxButton = ({ labelOn, labelOff, onChange, reset }) => {
+	const [isChecked, setIsChecked] = useState(false);
+	const [isFocused, setIsFocused] = useState(false);
+
+	useEffect(() => {
+		if (reset) {
+			setIsChecked(false);
+			onChange(false); //to tell our x button to reset
+		}
+	}, [reset, onChange]);
+
+
+	const handleDivClick = () => {
+		const newCheckedState = !isChecked;
+		setIsChecked(newCheckedState);
+		onChange(newCheckedState);
+	};
+
+	const handleKeyPress = (event) => {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			handleDivClick();
+		}
+	};
+
+	const handleFocus = (event) => {
+		setIsFocused(true);
+		const parentDiv = event.target.closest('.CheckboxButton');
+		if (parentDiv) {
+			parentDiv.classList.add('focused');
+		}
+	};
+
+	const handleBlur = (event) => {
+		setIsFocused(false);
+		const parentDiv = event.target.closest('.CheckboxButton');
+		if(parentDiv) {
+			parentDiv.classList.remove('focused');
+		}
+	};
+
+	return (
+	<div
+		className={`CheckboxButton ${isChecked ? 'on' : 'off'}`}
+		onClick={handleDivClick}
+		onKeyDown={handleKeyPress}
+		onFocus={handleFocus}
+		onBlur={handleBlur}
+
+	>
+	<label>{isChecked ? labelOn : labelOff}</label>
+		<input
+			type="checkbox"
+			checked={isChecked}
+			onChange={() => {}}
+			tabIndex="0"
+		/>
+	</div>
+  );
+};
+
+export default CheckboxButton;
+

--- a/src/components/checkbox-button.scss
+++ b/src/components/checkbox-button.scss
@@ -1,0 +1,44 @@
+.CheckboxButton {
+  padding: 1.5px;
+  cursor: pointer;
+  background-color: lightgray;
+  color: black;
+  text-align: center;
+  border-radius: 4px;
+  // min-width: 80px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  outline: none;
+}
+
+.CheckboxButton label {
+  font-size: 0.7rem;
+  cursor: pointer;
+  font-weight: normal;
+}
+
+.CheckboxButton input {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.CheckboxButton.on {
+  background-color: #d9a0ff;
+  color: black;
+}
+
+.CheckboxButton.off {
+  background-color: #5e5c5c;
+  color: white;
+}
+
+.CheckboxButton.focused {
+  outline: 3px solid #3b82f6;
+  // outline-offset: 2px;
+}

--- a/src/components/checkbox-button.scss
+++ b/src/components/checkbox-button.scss
@@ -1,44 +1,44 @@
 .CheckboxButton {
-  padding: 1.5px;
-  cursor: pointer;
-  background-color: lightgray;
-  color: black;
-  text-align: center;
-  border-radius: 4px;
-  // min-width: 80px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  outline: none;
+	padding: 1.5px;
+	cursor: pointer;
+	background-color: lightgray;
+	color: black;
+	text-align: center;
+	border-radius: 4px;
+	// min-width: 80px;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	outline: none;
 }
 
 .CheckboxButton label {
-  font-size: 0.7rem;
-  cursor: pointer;
-  font-weight: normal;
+	font-size: 0.7rem;
+	cursor: pointer;
+	font-weight: normal;
 }
 
 .CheckboxButton input {
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	height: 1px;
+	overflow: hidden;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
 }
 
 .CheckboxButton.on {
-  background-color: #d9a0ff;
-  color: black;
+	background-color: #d9a0ff;
+	color: black;
 }
 
 .CheckboxButton.off {
-  background-color: #5e5c5c;
-  color: white;
+	background-color: #5e5c5c;
+	color: white;
 }
 
 .CheckboxButton.focused {
-  outline: 3px solid #3b82f6;
-  // outline-offset: 2px;
+	outline: 3px solid #3b82f6;
+	// outline-offset: 2px;
 }

--- a/src/components/my-widgets-page.scss
+++ b/src/components/my-widgets-page.scss
@@ -118,7 +118,7 @@
 
 			.filtersGroup {
 				display: flex;
-                gap: 5px;
+				gap: 5px;
 				padding-bottom: 0.5rem;
 				padding-top: 0.1rem;
 			}

--- a/src/components/my-widgets-page.scss
+++ b/src/components/my-widgets-page.scss
@@ -160,9 +160,9 @@
 
 				.search-close {
 					// position: absolute;
-					top: 8px;
-					right: 40px;
-					margin-top: 1px;
+					// top: 8px;
+					// right: 40px;
+					margin-top: -1px;
 					color: rgb(221, 221, 221);
 					cursor: pointer;
 				}

--- a/src/components/my-widgets-page.scss
+++ b/src/components/my-widgets-page.scss
@@ -116,6 +116,13 @@
 				align-items: center;
 			}
 
+			.filtersGroup {
+				display: flex;
+                gap: 5px;
+				padding-bottom: 0.5rem;
+				padding-top: 0.1rem;
+			}
+
 
 			.search {
 				// position: relative;
@@ -176,7 +183,7 @@
 
 				.textbox-background {
 					// position: absolute;
-                    display: flex;
+					display: flex;
 					width: 205px;
 					height: 20px;
 					left: 9px;

--- a/src/components/my-widgets-page.scss
+++ b/src/components/my-widgets-page.scss
@@ -108,9 +108,18 @@
 				// background: linear-gradient(#83caf3 16%, #37a9e6 89%);
 			}
 
+			.searchContainer {
+				//maybe some display flex
+				display: flex;
+				flex-direction: column;
+				justify-content: center;
+				align-items: center;
+			}
+
+
 			.search {
-				position: relative;
-				padding: 10px 0 30px 0;
+				// position: relative;
+				padding: 10px 0 0 0;
 
 				background: #ebebeb;
 
@@ -130,7 +139,7 @@
 				}
 
 				.search-icon {
-					position: absolute;
+					// position: absolute;
 					top: 12px;
 					left: 13px;
 					height: 14px;
@@ -143,7 +152,7 @@
 				}
 
 				.search-close {
-					position: absolute;
+					// position: absolute;
 					top: 8px;
 					right: 40px;
 					margin-top: 1px;
@@ -152,7 +161,7 @@
 				}
 
 				.textbox {
-					position: absolute;
+					// position: absolute;
 					border: none;
 					outline: none;
 					width: 165px;
@@ -166,7 +175,8 @@
 				}
 
 				.textbox-background {
-					position: absolute;
+					// position: absolute;
+                    display: flex;
 					width: 205px;
 					height: 20px;
 					left: 9px;
@@ -174,6 +184,7 @@
 					border: solid 1px #b0b0b0;
 					border-radius: 12px;
 				}
+
 			}
 
 			// .courses {

--- a/src/components/my-widgets-side-bar.jsx
+++ b/src/components/my-widgets-side-bar.jsx
@@ -40,31 +40,46 @@ const MyWidgetsSideBar = ({ instances, isFetching, selectedId, onClick, beardMod
 
 	let searchBoxRender = null
 	if (isFetching) {
-		searchBoxRender = 
+		searchBoxRender =
 		<div className='search loading'>
 			<LoadingIcon size='sm' width='20px' left='10px'/>
 			<span className='loading-message'>Loading Widgets...</span>
 		</div>
 	} else {
 		searchBoxRender =
-			<div className='search'>
-				<div className='textbox-background'></div>
-				<input className='textbox'
-					type='text'
+			<div className='searchContainer'>
+				<div className='search'>
+			<div className="textbox-background">
+				{/* Search Icon */}
+				<div className="search-icon">
+					<svg viewBox="0 0 250.313 250.313">
+						<path d="m244.19 214.6l-54.379-54.378c-0.289-0.289-0.628-0.491-0.93-0.76 10.7-16.231 16.945-35.66 16.945-56.554 0-56.837-46.075-102.91-102.91-102.91s-102.91 46.075-102.91 102.91c0 56.835 46.074 102.91 102.91 102.91 20.895 0 40.323-6.245 56.554-16.945 0.269 0.301 0.47 0.64 0.759 0.929l54.38 54.38c8.169 8.168 21.413 8.168 29.583 0 8.168-8.169 8.168-21.413 0-29.582zm-141.28-44.458c-37.134 0-67.236-30.102-67.236-67.235 0-37.134 30.103-67.236 67.236-67.236 37.132 0 67.235 30.103 67.235 67.236s-30.103 67.235-67.235 67.235z"
+						clipRule="evenodd"
+						fillRule="evenodd"/>
+					</svg>
+				</div>
+
+				{/* Search Input */}
+				<input
+					className="textbox"
+					type="text"
 					value={searchText}
 					onChange={handleSearchInputChange}
 				/>
-				<div className='search-icon'>
-					<svg viewBox='0 0 250.313 250.313'>
-						<path d='m244.19 214.6l-54.379-54.378c-0.289-0.289-0.628-0.491-0.93-0.76 10.7-16.231 16.945-35.66 16.945-56.554 0-56.837-46.075-102.91-102.91-102.91s-102.91 46.075-102.91 102.91c0 56.835 46.074 102.91 102.91 102.91 20.895 0 40.323-6.245 56.554-16.945 0.269 0.301 0.47 0.64 0.759 0.929l54.38 54.38c8.169 8.168 21.413 8.168 29.583 0 8.168-8.169 8.168-21.413 0-29.582zm-141.28-44.458c-37.134 0-67.236-30.102-67.236-67.235 0-37.134 30.103-67.236 67.236-67.236 37.132 0 67.235 30.103 67.235 67.236s-30.103 67.235-67.235 67.235z'
-							clipRule='evenodd'
-							fillRule='evenodd'/>
-					</svg>
-				</div>
-				<div className='search-close'
-					onClick={handleSearchCloseClick}>
+
+				{/* Search Close */}
+				<div className="search-close" onClick={handleSearchCloseClick}>
 					x
 				</div>
+
+				</div>
+
+				</div>
+
+				<div className='filtersGroup' >
+					<button className='filterButton'>Has Score</button>
+				</div>
+
 			</div>
 	}
 

--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -455,6 +455,8 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 				})
 
 				setCreatorState({...creatorState, heartbeatEnabled: false})
+                //also update the text on the Save Draft Button
+                setCreatorState({ ...creatorState, saveText: 'Failed to save' })
 			} else {
 				setAlertDialog({
 					enabled: true,
@@ -463,6 +465,9 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 					fatal: false,
 					enableLoginButton: false
 				})
+                //also update the text on the Save Draft Button
+                setCreatorState({ ...creatorState, saveText: 'Failed to save' })
+
 			}
 		} else {
 			setAlertDialog({
@@ -472,6 +477,9 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 				fatal: false,
 				enableLoginButton: false
 			})
+            //also update the text on the Save Draft Button
+            setCreatorState({ ...creatorState, saveText: 'Failed to save' })
+
 		}
 	}
 

--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -39,7 +39,8 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		popupState: null,
 		returnUrl: null,
 		returnLocation: 'Widget Catalog',
-		directUploadMediaFile: null
+		directUploadMediaFile: null,
+        isTimeoutRunning: false
 	})
 
 	const [alertDialog, setAlertDialog] = useState({
@@ -295,6 +296,13 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		if (!!saveWidgetComplete) {
 			if (saveWidgetComplete == 'save') {
 				setCreatorState(creatorState => ({...creatorState, saveText: 'Draft Saved', saveStatus: 'idle'}))
+                if(!creatorState.isTimeoutRunning) {
+                    //this line is needed again or else the text will revert to 'Save Draft' immidietly
+                    setCreatorState({...creatorState, saveText: 'Draft Saved', saveStatus: 'idle', isTimeoutRunning: true})
+                    setTimeout( () => {
+                        setCreatorState( {...creatorState, saveText: 'Save Draft', isTimeoutRunning:false} )
+                    } , 5000) //text gets reverted after 5 seconds(format is millisecond)
+                }
 			}
 			else if (saveWidgetComplete == 'preview') {
 				setCreatorState(creatorState => ({...creatorState, saveStatus: 'idle'}))
@@ -469,6 +477,14 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
                 setCreatorState({ ...creatorState, saveText: 'Failed to save' })
 
 			}
+            if(!creatorState.isTimeoutRunning) {
+                setCreatorState({...creatorState, saveText: 'Failed to save', saveStatus: 'idle', isTimeoutRunning: true})
+                setTimeout( () => {
+                    setCreatorState( {...creatorState, saveText: 'Save Draft', isTimeoutRunning:false} )
+                } , 5000) //text gets reverted after 5 seconds(format is millisecond)
+            }
+
+
 		} else {
 			setAlertDialog({
 				enabled: true,
@@ -479,6 +495,14 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 			})
             //also update the text on the Save Draft Button
             setCreatorState({ ...creatorState, saveText: 'Failed to save' })
+            if(!creatorState.isTimeoutRunning) {
+                setCreatorState({...creatorState, saveText: 'Failed to save', saveStatus: 'idle', isTimeoutRunning: true})
+                setTimeout( () => {
+                    setCreatorState( {...creatorState, saveText: 'Save Draft', isTimeoutRunning:false} )
+                } , 5000) //text gets reverted after 5 seconds(format is millisecond)
+            }
+
+
 
 		}
 	}

--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -455,7 +455,7 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 				})
 
 				setCreatorState({...creatorState, heartbeatEnabled: false})
-                //also update the text on the Save Draft Button
+                //also update the text on the Save Draft Buttons
                 setCreatorState({ ...creatorState, saveText: 'Failed to save' })
 			} else {
 				setAlertDialog({

--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -40,7 +40,7 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		returnUrl: null,
 		returnLocation: 'Widget Catalog',
 		directUploadMediaFile: null,
-        isTimeoutRunning: false
+		isTimeoutRunning: false
 	})
 
 	const [alertDialog, setAlertDialog] = useState({
@@ -296,13 +296,9 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		if (!!saveWidgetComplete) {
 			if (saveWidgetComplete == 'save') {
 				setCreatorState(creatorState => ({...creatorState, saveText: 'Draft Saved', saveStatus: 'idle'}))
-                if(!creatorState.isTimeoutRunning) {
-                    //this line is needed again or else the text will revert to 'Save Draft' immidietly
-                    setCreatorState({...creatorState, saveText: 'Draft Saved', saveStatus: 'idle', isTimeoutRunning: true})
-                    setTimeout( () => {
-                        setCreatorState( {...creatorState, saveText: 'Save Draft', isTimeoutRunning:false} )
-                    } , 5000) //text gets reverted after 5 seconds(format is millisecond)
-                }
+				if(!creatorState.isTimeoutRunning) {
+					setCreatorState({...creatorState, saveText: 'Draft Saved', saveStatus: 'idle', isTimeoutRunning: true});
+				}
 			}
 			else if (saveWidgetComplete == 'preview') {
 				setCreatorState(creatorState => ({...creatorState, saveStatus: 'idle'}))
@@ -311,6 +307,21 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 			setSaveWidgetComplete(null)
 		}
 	},[saveWidgetComplete])
+
+	useEffect( () => {
+		if(creatorState.isTimeoutRunning) {
+			const timeoutID = setTimeout( () => {
+				setCreatorState( prevState => ({
+					...prevState,
+					saveText: 'Save Draft',
+					isTimeoutRunning: false
+				}));
+			}, 5000);
+
+			return () => clearTimeout(timeoutID);
+		}
+
+	}, [creatorState.isTimeoutRunning]);
 
 	/* =========== postMessage handlers =========== */
 
@@ -462,9 +473,13 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 					enableLoginButton: true
 				})
 
-				setCreatorState({...creatorState, heartbeatEnabled: false})
-                //also update the text on the Save Draft Buttons
-                setCreatorState({ ...creatorState, saveText: 'Failed to save' })
+				setCreatorState({
+					...creatorState,
+					heartbeatEnabled: false,
+					saveText: 'Failed to save',
+					saveStatus: 'idle',
+					isTimeoutRunning: true
+				});
 			} else {
 				setAlertDialog({
 					enabled: true,
@@ -473,17 +488,15 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 					fatal: false,
 					enableLoginButton: false
 				})
-                //also update the text on the Save Draft Button
-                setCreatorState({ ...creatorState, saveText: 'Failed to save' })
+				//also update the text on the Save Draft Button
+				setCreatorState({
+					...creatorState,
+					saveText: 'Failed to save',
+					saveStatus: 'idle',
+					isTimeoutRunning: true
+				});
 
 			}
-            if(!creatorState.isTimeoutRunning) {
-                setCreatorState({...creatorState, saveText: 'Failed to save', saveStatus: 'idle', isTimeoutRunning: true})
-                setTimeout( () => {
-                    setCreatorState( {...creatorState, saveText: 'Save Draft', isTimeoutRunning:false} )
-                } , 5000) //text gets reverted after 5 seconds(format is millisecond)
-            }
-
 
 		} else {
 			setAlertDialog({
@@ -493,16 +506,12 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 				fatal: false,
 				enableLoginButton: false
 			})
-            //also update the text on the Save Draft Button
-            setCreatorState({ ...creatorState, saveText: 'Failed to save' })
-            if(!creatorState.isTimeoutRunning) {
-                setCreatorState({...creatorState, saveText: 'Failed to save', saveStatus: 'idle', isTimeoutRunning: true})
-                setTimeout( () => {
-                    setCreatorState( {...creatorState, saveText: 'Save Draft', isTimeoutRunning:false} )
-                } , 5000) //text gets reverted after 5 seconds(format is millisecond)
-            }
-
-
+			setCreatorState({
+				...creatorState,
+				saveText: 'Failed to save',
+				saveStatus: 'idle',
+				isTimeoutRunning: true
+			});
 
 		}
 	}


### PR DESCRIPTION
In this pull request I have added 3 buttons underneath the My Widget Page in Materia for more advanced filtering. 

# Changes 
I ended up changing the styles of the sidebar to be more flexible(no pun intended) so it makes more sense and so that it can comply with my button additions. 

For the actual filters I made them check boxes with a parent of a clickable div. They change color when clicked or when you press the keyboard when they are focused. When they are focused I gave them a nice blue highlight to the parent div similar to how I did it in connections. 

The three filters I added are `Drafts:On/Off` , `Published:On/Off` and `Has Score:On/Off` 
These filters will filter based on the properties of the instance object for `instance` with properties of `draft` for both buttons `Drafts: On/Off` and `Published: On/Off`. For the filter `Has Score:On/Off`, I made an api call to get the scores instead of looking at the properties of the instance since the `attempts` property seems to always be -1. 

