### PR TITLE
Fix for score module attempt limit validation

### DIFF
--- a/fuel/app/classes/materia/score/module.php
+++ b/fuel/app/classes/materia/score/module.php
@@ -96,7 +96,8 @@ abstract class Score_Module
 			// Check for attempt limit prior to submission, but only for actual plays (not previews)
 			if ($this->play_id != -1)
 			{
-				$attempts_used = count(\Materia\Score_Manager::get_instance_score_history($this->inst->id, $this->play->context_id));
+				$semester = Semester::get_current_semester();
+				$attempts_used = count(\Materia\Score_Manager::get_instance_score_history($this->inst->id, $this->play->context_id, $semester));
 				if ($this->inst->attempts != -1 && $attempts_used >= $this->inst->attempts)
 				{
 					throw new Score_Exception('Attempt Limit Met', 'You have already met the attempt limit for this widget and cannot submit additional scores.');


### PR DESCRIPTION
Resolves #1611. Adds the `$semester` param to the `\Materia\Score_Manager::get_instance_score_history()` reference in the score module as part of its attempt limit validation.