### PR TITLE
Revamp widget individual student scores table

### DIFF
--- a/public/img/arrow_right_with_stem.svg
+++ b/public/img/arrow_right_with_stem.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="48px" viewBox="0 -960 960 960" width="48px" fill="#000000"><path d="M567-416H146v-128h421L388-723l92-91 334 334-334 334-91-91 178-179Z"/></svg>

--- a/src/components/my-widgets-score-semester-individual.jsx
+++ b/src/components/my-widgets-score-semester-individual.jsx
@@ -100,136 +100,92 @@ const MyWidgetScoreSemesterIndividual = ({ semester, instId, setInvalidLogin }) 
 		mainContentRender = <div className='error'>{error}</div>
 	}
 	else if (!state.isLoading) {
-		const userRowElements = state.filteredLogs.map(user => (
-			<tr
-				key={user.userId}
-				title={`View all scores for ${user.name}`}
-				onClick={() => { setState({ ...state, selectedUser: user }) }}
-				className={{ rowSelected: state.selectedUser.userId === user.userId }}
-			>
-				<td className={`listName ${state.selectedUser.userId === user.userId ? 'selected' : ''}`}>
-					{user.name}
-				</td>
-			</tr>
-		))
+		const studentSearch = (
+			<>
+				<input
+					type='text'
+					value={state.searchText}
+					onChange={(e) => setState({...state, searchText: e.target.value})}
+					placeholder='Search Students'
+				/>
+				{state.filteredLogs.length === 0 && (
+					<h3 style={{ paddingTop: '5px' }}>No users match that search.</h3>
+				)}
+			</>
+		)
 
-		let selectedUserRender = null
-		if (state.selectedUser.userId != undefined) {
-			const selectedUserScoreRows = state.selectedUser.scores.map(score => (
-				<tr
-					key={score.playId}
-					title='View Detailed Scores for this Play'
-					onClick={() => { showScore(instId, score.playId) }}
-				>
-					<td>{timestampToDateDisplay(score.created_at)}</td>
-					<td>{score.score}</td>
-					<td>{score.elapsed}</td>
-				</tr>
-			))
+		const studentList = (
+			<ul aria-label="Students">
+				{state.filteredLogs.map(user => (
+					<li key={user.id}>
+						<button
+							className={state.selectedUser.userId === user.userId ? 'buttonSelected' : ''}
+							onClick={() => {
+								setState({...state, selectedUser: user})
+							}}
+						>
+							{user.name}
+						</button>
+					</li>
+				))}
+			</ul>
+		)
 
-			selectedUserRender = (
-				<div className='scoreTableContainer'>
-					<table className='scoreTable'>
-						<tbody>
-							{selectedUserScoreRows}
-						</tbody>
-					</table>
-				</div>
-			)
-		}
+		const selectedStudentScores = (
+			<>
+				{/* No user selected */}
+				{!state.selectedUser.userId && (
+					<h3 className="centeredText">Select a student to view their scores.</h3>
+				)}
 
-		else if (state.filteredLogs.length == 0) {
-			selectedUserRender = <p className='no-user-search-results'>No users match that search.</p>
-		}
+				{/* User selected, display score table */}
+				{state.selectedUser.userId && (
+					<>
+						<h3>{`${state.selectedUser.name}'s scores`}</h3>
+						<table>
+							<tbody>
+							<tr>
+								<th>Date</th>
+								<th>Score</th>
+								<th>Duration</th>
+								<th aria-label="View Details Button"></th>
+							</tr>
+							{state.selectedUser.scores.map(score => (
+								<tr key={score.playId}>
+									<td>{timestampToDateDisplay(score.created_at)}</td>
+									<td>{score.score}</td>
+									<td>{score.elapsed}</td>
+									<td>
+										<button
+											onClick={() => showScore(instId, score.playId)}
+											title="View Detailed Scores for this Play"
+										>
+											<img src="/img/arrow_right_with_stem.svg" />
+										</button>
+									</td>
+								</tr>
+							))}
+							</tbody>
+						</table>
+					</>
+				)}
+			</>
+		)
 
 		mainContentRender = (
 			<>
 				<div className='scoreListContainer'>
 					{/* List of students */}
 					<div className='scoreListStudentSelector'>
-						{/* Student search */}
-						<input
-							type='text'
-							value={state.searchText}
-							onChange={(e) => setState({...state, searchText: e.target.value})}
-							placeholder='Search Students'
-						/>
-
-						{/* Student buttons */}
-						{state.filteredLogs.length === 0 && (
-							<h3 style={{ paddingTop: '5px' }}>No users match that search.</h3>
-						)}
-
-						<ul aria-label="Students">
-							{state.filteredLogs.map(user => (
-								<li key={user.id}>
-									<button
-										className={state.selectedUser.userId === user.userId ? 'buttonSelected' : ''}
-										onClick={() => {
-											setState({...state, selectedUser: user})
-										}}
-									>
-										{user.name}
-									</button>
-								</li>
-							))}
-						</ul>
+						{studentSearch}
+						{studentList}
 					</div>
 
 					{/* Selected student scores */}
 					<div className='scoreListStudentScoreTable'>
-						{/* No user selected */}
-						{!state.selectedUser.userId && (
-							<h3 className="centeredText">Select a student to view their scores.</h3>
-						)}
-
-						{/* User selected, display score table */}
-						{state.selectedUser.userId && (
-							<>
-								<h3>{`${state.selectedUser.name}'s scores`}</h3>
-								<table>
-									<tbody>
-										<tr>
-											<th>Date</th>
-											<th>Score</th>
-											<th>Duration</th>
-											<th aria-label="View Details Button"></th>
-										</tr>
-										{state.selectedUser.scores.map(score => (
-											<tr
-												key={score.playId}
-												title='View Detailed Scores for this Play'
-											>
-												<td>{timestampToDateDisplay(score.created_at)}</td>
-												<td>{score.score}</td>
-												<td>{score.elapsed}</td>
-												<td>
-													<button onClick={() => showScore(instId, score.playId)}>Go</button>
-												</td>
-											</tr>
-										))}
-									</tbody>
-								</table>
-							</>
-						)}
+						{selectedStudentScores}
 					</div>
 				</div>
-
-				{/*<h3>Select a student to view their scores.</h3>*/}
-
-
-				{/*{state.filteredLogs.length > 0 && (*/}
-				{/*	<div className='scoreListContainer'>*/}
-				{/*		<div className='scoreListScrollContainer'>*/}
-				{/*			<table className='scoreListTable'>*/}
-				{/*				<tbody>*/}
-				{/*				{userRowElements}*/}
-				{/*				</tbody>*/}
-				{/*			</table>*/}
-				{/*		</div>*/}
-				{/*	</div>*/}
-				{/*)}*/}
-				{/*{selectedUserRender}*/}
 			</>
 		)
 	}

--- a/src/components/my-widgets-score-semester-individual.jsx
+++ b/src/components/my-widgets-score-semester-individual.jsx
@@ -1,5 +1,5 @@
 
-import React, {useState, useEffect, useCallback, useRef, useId} from 'react'
+import React, { useState, useEffect, useCallback, useRef, useId } from 'react'
 import { useQueryClient, useQuery } from 'react-query'
 import { apiGetPlayLogs } from '../util/api'
 import MyWidgetScoreSemesterSummary from './my-widgets-score-semester-summary'

--- a/src/components/my-widgets-score-semester-individual.jsx
+++ b/src/components/my-widgets-score-semester-individual.jsx
@@ -144,25 +144,92 @@ const MyWidgetScoreSemesterIndividual = ({ semester, instId, setInvalidLogin }) 
 
 		mainContentRender = (
 			<>
-				<div className='score-search'>
-					<input type='text'
-						value={state.searchText}
-						onChange={(e) => setState({...state, searchText: e.target.value})}
-						placeholder='Search Students'
-					/>
-				</div>
-
-				<h3>Select a student to view their scores.</h3>
 				<div className='scoreListContainer'>
-					<div className='scoreListScrollContainer'>
-						<table className='scoreListTable'>
-							<tbody>
-								{userRowElements}
-							</tbody>
-						</table>
+					{/* List of students */}
+					<div className='scoreListStudentSelector'>
+						{/* Student search */}
+						<input
+							type='text'
+							value={state.searchText}
+							onChange={(e) => setState({...state, searchText: e.target.value})}
+							placeholder='Search Students'
+						/>
+
+						{/* Student buttons */}
+						{state.filteredLogs.length === 0 && (
+							<h3 style={{ paddingTop: '5px' }}>No users match that search.</h3>
+						)}
+
+						<ul aria-label="Students">
+							{state.filteredLogs.map(user => (
+								<li key={user.id}>
+									<button
+										className={state.selectedUser.userId === user.userId ? 'buttonSelected' : ''}
+										onClick={() => {
+											setState({...state, selectedUser: user})
+										}}
+									>
+										{user.name}
+									</button>
+								</li>
+							))}
+						</ul>
+					</div>
+
+					{/* Selected student scores */}
+					<div className='scoreListStudentScoreTable'>
+						{/* No user selected */}
+						{!state.selectedUser.userId && (
+							<h3 className="centeredText">Select a student to view their scores.</h3>
+						)}
+
+						{/* User selected, display score table */}
+						{state.selectedUser.userId && (
+							<>
+								<h3>{`${state.selectedUser.name}'s scores`}</h3>
+								<table>
+									<tbody>
+										<tr>
+											<th>Date</th>
+											<th>Score</th>
+											<th>Duration</th>
+											<th aria-label="View Details Button"></th>
+										</tr>
+										{state.selectedUser.scores.map(score => (
+											<tr
+												key={score.playId}
+												title='View Detailed Scores for this Play'
+											>
+												<td>{timestampToDateDisplay(score.created_at)}</td>
+												<td>{score.score}</td>
+												<td>{score.elapsed}</td>
+												<td>
+													<button onClick={() => showScore(instId, score.playId)}>Go</button>
+												</td>
+											</tr>
+										))}
+									</tbody>
+								</table>
+							</>
+						)}
 					</div>
 				</div>
-				{selectedUserRender}
+
+				{/*<h3>Select a student to view their scores.</h3>*/}
+
+
+				{/*{state.filteredLogs.length > 0 && (*/}
+				{/*	<div className='scoreListContainer'>*/}
+				{/*		<div className='scoreListScrollContainer'>*/}
+				{/*			<table className='scoreListTable'>*/}
+				{/*				<tbody>*/}
+				{/*				{userRowElements}*/}
+				{/*				</tbody>*/}
+				{/*			</table>*/}
+				{/*		</div>*/}
+				{/*	</div>*/}
+				{/*)}*/}
+				{/*{selectedUserRender}*/}
 			</>
 		)
 	}
@@ -170,7 +237,7 @@ const MyWidgetScoreSemesterIndividual = ({ semester, instId, setInvalidLogin }) 
 	return (
 		<>
 			<div className={`display table ${state.isLoading === true ? 'loading' : ''}`}
-				id={`table_${semester.id}`} >
+					 id={`table_${semester.id}`}>
 				{mainContentRender}
 			</div>
 			<MyWidgetScoreSemesterSummary {...semester} />

--- a/src/components/my-widgets-score-semester-individual.jsx
+++ b/src/components/my-widgets-score-semester-individual.jsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect, useCallback, useRef } from 'react'
+import React, {useState, useEffect, useCallback, useRef, useId} from 'react'
 import { useQueryClient, useQuery } from 'react-query'
 import { apiGetPlayLogs } from '../util/api'
 import MyWidgetScoreSemesterSummary from './my-widgets-score-semester-summary'
@@ -96,6 +96,8 @@ const MyWidgetScoreSemesterIndividual = ({ semester, instId, setInvalidLogin }) 
 	}, [state.searchText, state.selectedUser, state.logs])
 
 	let mainContentRender = <LoadingIcon width='570px' />
+	const studentScoresHeaderId = useId()
+
 	if (error) {
 		mainContentRender = <div className='error'>{error}</div>
 	}
@@ -141,8 +143,8 @@ const MyWidgetScoreSemesterIndividual = ({ semester, instId, setInvalidLogin }) 
 				{/* User selected, display score table */}
 				{state.selectedUser.userId && (
 					<>
-						<h3>{`${state.selectedUser.name}'s scores`}</h3>
-						<table>
+						<h3 id={studentScoresHeaderId}>{`${state.selectedUser.name}'s scores`}</h3>
+						<table aria-labelledby={studentScoresHeaderId}>
 							<tbody>
 							<tr>
 								<th>Date</th>

--- a/src/components/my-widgets-scores.scss
+++ b/src/components/my-widgets-scores.scss
@@ -445,67 +445,27 @@
 						tr:last-child td {
 							border-bottom: none;
 						}
-					}
-				}
-			}
 
-			.scoreTableContainer {
-				position: relative;
-				z-index: 1;
-				float: left;
-				width: 55%;
-				right: 5px;
+						td button {
+							display: flex;
+							border: none;
+							background: transparent;
+							padding: 4px;
+							border-radius: 3px;
+							transition: background-color 0.1s;
 
-				margin-top: 15px;
-				padding: 10px 0 10px 0;
+							img {
+								width: 16px;
+								height: 16px;
+							}
 
-				background: #ffffff;
-				border-radius: 3px;
-				box-shadow: 0 3px 3px rgba(0, 0, 0, 0.3);
-
-				.scoreTable {
-					width: 95%;
-					margin-left: 10px;
-					border-collapse: collapse;
-
-					.elapsed {
-						text-align: right;
-					}
-
-					td {
-						border: none;
-						border-bottom: solid #dbdbdb 1px;
-					}
-
-					tr {
-						cursor: pointer;
-
-						&:hover {
-							background: #ffe0a5;
-						}
-
-						&:last-child td {
-							border-bottom: none;
+							&:hover {
+								cursor: pointer;
+								background-color: #00000011;
+							}
 						}
 					}
 				}
-			}
-
-			.scoreTableTitle {
-				height: 1.5em;
-			}
-
-			thead tr {
-				background: #cdcdcd;
-			}
-
-			td {
-				height: 1.5em;
-				padding: 6px 3px;
-			}
-
-			tbody tr.rowSelected {
-				background: #ffcb68;
 			}
 		}
 	}

--- a/src/components/my-widgets-scores.scss
+++ b/src/components/my-widgets-scores.scss
@@ -361,6 +361,7 @@
 			.scoreListContainer {
 				display: flex;
 				width: 100%;
+				max-height: 300px;
 
 				.centeredText {
 					display: flex;
@@ -377,9 +378,10 @@
 					background: rgba(0, 0, 0, 0.05);
 					padding: 10px 10px;
 					gap: 10px;
+					width: 35%;
+					overflow-y: auto;
 
 					input[type='text'] {
-						width: 190px;
 						border: solid 1px #b0b0b0;
 						border-radius: 12px;
 						height: 19px;
@@ -421,10 +423,11 @@
 
 				.scoreListStudentScoreTable {
 					display: flex;
+					flex: 1;
 					flex-direction: column;
 					gap: 10px;
-					flex: 1;
 					padding: 10px;
+					overflow-y: auto;
 
 					table {
 						width: 100%;

--- a/src/components/my-widgets-scores.scss
+++ b/src/components/my-widgets-scores.scss
@@ -17,9 +17,9 @@
 		padding: 0;
 
 		border-bottom: #999 dotted 1px;
-	
+
 		.action_button {
-			
+
 			color: $extremely-dark-gray;
 			text-shadow: 1px 1px 1px rgba(255, 255, 255, 0.5);
 			box-shadow: 1px 2px 4px #ececec;
@@ -64,7 +64,7 @@
 		color: #000000;
 	}
 
-	
+
 
 	.scoreWrapper {
 		display: flex;
@@ -92,12 +92,12 @@
 				margin: 15px 0 0 0;
 				padding: 0;
 				height: 23px;
-	
+
 				li {
 					list-style: none;
 					display: inline-block;
 					padding-right: 3px;
-	
+
 					a {
 						color: #000000;
 						padding: 6px 10px 4px 10px;
@@ -106,13 +106,13 @@
 						border-right: solid #dbdbdb 1px;
 						padding-bottom: 5px;
 						cursor: pointer;
-	
+
 						&:hover {
 							text-decoration: none;
 						}
 					}
 				}
-	
+
 				li.scoreTypeSelected a {
 					background: #f3f3f3;
 				}
@@ -128,7 +128,7 @@
 				width: 105px;
 				margin: 0;
 				padding: 0;
-	
+
 				li {
 					padding: 5px;
 					margin: 0 0 10px 0;
@@ -138,7 +138,7 @@
 					text-align: center;
 					background: #e9edef;
 					border-radius: 5px;
-	
+
 					p {
 						padding: 0;
 						margin: 0;
@@ -148,7 +148,7 @@
 						font-weight: 900;
 						font-family: 'Kameron', Georgia, 'Times New Roman', Times, serif;
 					}
-	
+
 					h4 {
 						padding: 0;
 						margin: 0;
@@ -202,15 +202,10 @@
 		}
 
 		.display.table {
+			display: flex;
 			background: #f3f3f3;
-			margin: 0;
-			padding: 20px;
-			border: solid #dbdbdb 1px;
-			float: left;
 			width: 570px;
 			min-height: 300px;
-			padding: 0 0 25px 0;
-			display: block;
 
 			&.loading {
 				display: flex;
@@ -356,70 +351,101 @@
 		.table {
 			h3 {
 				font-family: 'Lucida Grande', sans-serif;
-				margin-top: 10px;
-				margin-left: 20px;
 				font-size: 1em;
 				font-weight: normal;
 				color: #666;
-			}
-
-			.score-search {
-				background: rgba(0, 0, 0, 0.05);
-				padding: 6px 10px 10px 10px;
-
-				input[type='text'] {
-					width: 190px;
-					margin: 7px 10px 0 10px;
-					border: solid 1px #b0b0b0;
-					border-radius: 12px;
-					height: 19px;
-					background: #fff url('/img/magnifyingglass.png') 5px 50% no-repeat;
-					padding-left: 23px;
-					padding-right: 10px;
-					outline: none;
-				}
+				margin: 0;
+				text-align: center;
 			}
 
 			.scoreListContainer {
-				position: relative;
-				z-index: 3;
-				float: left;
-				width: 40%;
-				margin-left: 20px;
+				display: flex;
+				width: 100%;
 
-				background: #ffffff;
-				border-radius: 3px;
-
-				box-shadow: 0 3px 3px rgba(0, 0, 0, 0.3);
-
-				.scoreListScrollContainer {
-					max-height: 550px;
+				.centeredText {
+					display: flex;
 					width: 100%;
-					overflow: auto;
+					height: 100%;
+					justify-content: center;
+					align-items: center;
+					text-align: center;
+				}
 
-					.scoreListTable {
+				.scoreListStudentSelector {
+					display: flex;
+					flex-direction: column;
+					background: rgba(0, 0, 0, 0.05);
+					padding: 10px 10px;
+					gap: 10px;
+
+					input[type='text'] {
+						width: 190px;
+						border: solid 1px #b0b0b0;
+						border-radius: 12px;
+						height: 19px;
+						background: #fff url('/img/magnifyingglass.png') 5px 50% no-repeat;
+						padding-left: 23px;
+						padding-right: 10px;
+						outline: none;
+					}
+
+					ul {
+						display: flex;
+						flex-direction: column;
+						list-style-type: none;
+						padding: 0;
+						margin: 0;
+						gap: 5px;
+					}
+
+					button {
+						border: solid 1px #b0b0b0;
+						border-radius: 1000px;
 						width: 100%;
+						padding: 5px 10px;
+						background-color: white;
+						transition: background-color 0.1s;
 
-						.listName {
-							&.selected {
-								background: #ffe0a5;
-							}
+						&:hover {
+							cursor: pointer;
+							background-color: #d0eeff;
+							border-color: #9eb5c2
 						}
+					}
+
+					.buttonSelected {
+						background-color: #86d3ff;
+						border-color: #578ba9
 					}
 				}
 
-				.scoreListHead {
-					display: block;
-					height: 1.5em;
-					padding: 3px 0 0 5px;
-					background-color: #cdcdcd;
-					color: #000000;
-					text-decoration: none;
-				}
+				.scoreListStudentScoreTable {
+					display: flex;
+					flex-direction: column;
+					gap: 10px;
+					flex: 1;
+					padding: 10px;
 
-				tbody tr:hover {
-					background: #ffe0a5;
-					cursor: pointer;
+					table {
+						width: 100%;
+						border-collapse: collapse;
+
+						th, td {
+							border-top: solid 1px #bbb;
+							border-bottom: solid 1px #bbb;
+							text-align: start;
+							padding: 6px 6px;
+							height: unset;
+						}
+
+						tr:first-child th {
+							border-top: none;
+						}
+
+						tr:last-child td {
+							border-bottom: none;
+						}
+					}
 				}
 			}
 


### PR DESCRIPTION
This PR revamps the individual scores table found when viewing a widget instance on the 'My Widgets' page. The revamp came after looking into #1619, which instead led me to re-do the table as a whole since I felt the layout could be a lot better. 

As a result, this PR resolves #1619 and features a neater, more responsive, and more accessible table design.

Old:
![Screenshot 2024-11-21 at 2 01 24 PM](https://github.com/user-attachments/assets/5077dd7e-ee8e-444c-adbd-f0c88ec3cf84)

New:
![Screenshot 2024-11-21 at 2 28 07 PM](https://github.com/user-attachments/assets/2de162d8-6eab-4879-b3c1-1683339cc4cf)
![Screenshot 2024-11-21 at 2 29 14 PM](https://github.com/user-attachments/assets/b785a641-5eb0-4cc8-bf59-2a84172ef506)

