### PR TITLE
Fixes instance lock error message, staleTimer, and cacheTimer

### DIFF
--- a/src/components/include.scss
+++ b/src/components/include.scss
@@ -307,7 +307,7 @@ header {
 	}
 
 	a {
-		color: #0093e7; 
+		color: #0093e7;
 		text-decoration: none;
 
 		&:hover {
@@ -527,13 +527,13 @@ header {
 		height: 16px;
 		margin: 0 0.5em 0 0;
 		padding: 0;
-	
+
 		background-color: #fff;
 		border: 2px solid #7e7e7e;
 		border-radius: 4px;
-		
+
 		transition: all 0.3s;
-	
+
 		&:after {
 			content: '✓';
 			position: absolute;
@@ -575,13 +575,13 @@ header {
 		height: 16px;
 		margin: 0 0.5em 0 0;
 		padding: 0;
-	
+
 		background-color: #fff;
 		border: 2px solid #7e7e7e;
 		border-radius: 50%;
-		
+
 		transition: all 0.3s;
-	
+
 		&:after {
 			content: '';
 			position: absolute;
@@ -1092,7 +1092,7 @@ h1.logo {
 	}
 }
 
-.darkMode .page, .widget {
+.darkMode .page, .darkMode .widget {
 	.alert-wrapper {
 		background: rgba(0,0,0,0.66);
 

--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -169,7 +169,9 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		queryFn: () => apiGetWidgetLock(instance.id),
 		enabled: !!instance.id,
 		staleTime: 2 * (60 * 1000),//2mins
-		cacheTime: 3 * (60 * 1000), // 3mins
+		cacheTime: 3 * (60 * 1000),
+		refetchInterval: 2 * (60 * 1000),
+		refetchIntervalInBackground: true,
 		retry: false,
 		onSuccess: (success) => {
 			if (!success) {

--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -168,11 +168,14 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		queryKey: ['widget-lock', instance.id],
 		queryFn: () => apiGetWidgetLock(instance.id),
 		enabled: !!instance.id,
-		staleTime: Infinity,
+		staleTime: 2 * (60 * 1000),//2mins
+		cacheTime: 3 * (60 * 1000), // 3mins
 		retry: false,
 		onSuccess: (success) => {
 			if (!success) {
-				onInitFail('Someone else is editing this widget, you will be able to edit after they finish.')
+				onInitFail({
+					message: 'locked',
+				});
 			}
 		},
 		onError: (error) => {
@@ -719,6 +722,17 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 			setCreatorState({
 				...creatorState,
 				invalid: true
+			})
+		} else if (err.message == "locked") {
+			setCreatorState({
+				...creatorState,
+				invalid: true
+			})
+			setAlertDialog({ enabled: true,
+				title: 'Widget Locked',
+				message:'This widget is locked and cannot be modified until another collaborator is finished editing the widget. Please check again after a couple of minutes when the other collaborator has finished editing.',
+				fatal: true,
+				enableLoginButton: false
 			})
 		} else {
 			setAlertDialog(


### PR DESCRIPTION
This addresses issue #1583 where collaborators of a widget are not meant to edit a widget at the same time. Normally this does not happen, but it was still possible to edit a widget without acquiring the lock for the widget by copy-pasting the link of the creator into the browser.

 When they do this now, they are met with an informative alert and it prevents them from being able to close the alert or edit the widget. Additionally, the staleTimer was set to infinity before, which was responsible for requesting the key to the lock. The original creator would hold the lock for 2 minutes but after that it would not do more requests. This PR aims to fix this by adding 2 minutes to the staleTimer in addition adding 3 minutes for the cacheTimer to get rid of the cache every 3 minutes. 
 
 There was a minor bug on the include.scss where a dark mode style would be applied as well, I also fixed that with Simon's help. 