### PR TITLE
Adds application version number to home page.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-test-renderer": "^17.0.2",
     "sass": "^1.69.5",
     "sass-loader": "^13.2.0",
+    "string-replace-loader": "^3.1.0",
     "webpack": "^5.76.0",
     "webpack-cli": "^5.0.1",
     "webpack-dev-server": "^4.11.1",

--- a/src/components/homepage.jsx
+++ b/src/components/homepage.jsx
@@ -89,7 +89,7 @@ const Homepage = () => (
 					If you have an idea for a new widget or simply would like to give us feedback, we'd love to hear from you on <a href='https://github.com/ucfopen' target='_blank'>Github</a>.
 				</p>
 				<p className='copyright'>
-					&copy; {new Date().getFullYear()} University of Central Florida
+					__APP_VERSION_PLACEHOLDER__ &copy; {new Date().getFullYear()} University of Central Florida
 				</p>
 			</section>
 		</section>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,8 @@ const jsPath = path.join(__dirname, 'src',)
 const packageJsPath = path.join(__dirname, 'fuel','packages')
 const cssPath = path.join(__dirname, 'src', 'css')
 
+const packageJSON = require('./package.json')
+
 const entry = {}
 // Webpack Entry Point Registration Overview
 // Create object with:
@@ -80,6 +82,16 @@ module.exports = {
 					'sass-loader'
 				]
 			},
+			{
+				test: /homepage.jsx$/,
+				use: {
+					loader: 'string-replace-loader',
+					options: {
+						search: '__APP_VERSION_PLACEHOLDER__',
+						replace: `v${packageJSON.version}`
+					}
+				}
+			}
 		]
 	},
 	plugins: [

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -8,6 +8,9 @@ const jsPath = path.join(__dirname, 'src',)
 const packageJsPath = path.join(__dirname, 'fuel','packages')
 const cssPath = path.join(__dirname, 'src', 'css')
 
+// 
+const packageJSON = require('./package.json')
+
 /*
  *   Template Production webpack config for Materia
  *   This can be modified to suit your needs. By default it is run when building the materia-app image using the materia-app.Dockerfile
@@ -57,6 +60,16 @@ module.exports = {
 					'sass-loader'
 				]
 			},
+			{
+				test: /homepage.jsx$/,
+				use: {
+					loader: 'string-replace-loader',
+					options: {
+						search: '__APP_VERSION_PLACEHOLDER__',
+						replace: `v${packageJSON.version}`
+					}
+				}
+			}
 		]
 	},
 	plugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4974,7 +4974,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.2.3:
+json5@^2.1.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -5062,6 +5062,15 @@ loader-utils@^1.1.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
+
+loader-utils@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -6351,7 +6360,7 @@ scheduler@^0.23.2:
   dependencies:
     loose-envify "^1.1.0"
 
-schema-utils@^3.1.1, schema-utils@^3.2.0:
+schema-utils@^3.0.0, schema-utils@^3.1.1, schema-utils@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
   integrity sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==
@@ -6700,6 +6709,14 @@ string-length@^4.0.1:
   dependencies:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
+
+string-replace-loader@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-replace-loader/-/string-replace-loader-3.1.0.tgz#11ac6ee76bab80316a86af358ab773193dd57a4f"
+  integrity sha512-5AOMUZeX5HE/ylKDnEa/KKBqvlnFmRZudSOjVJHxhoJg9QYTwl1rECx7SLR8BBH7tfxb4Rp7EM2XVfQFxIhsbQ==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Closes #1634.

Adds a version indicator in the footer of the home page and adjusts webpack instructions to bake the current version number from the package.json file into the static code at build time.