### PR TITLE
Adds featured flag to widget table

### DIFF
--- a/fuel/app/classes/materia/widget.php
+++ b/fuel/app/classes/materia/widget.php
@@ -14,6 +14,7 @@ class Widget
 	public $id                     = 0;
 	public $is_answer_encrypted    = true;
 	public $in_catalog             = true;
+	public $featured               = false;
 	public $is_editable            = true;
 	public $is_playable            = true;
 	public $is_qset_encrypted      = true;
@@ -101,6 +102,7 @@ class Widget
 			'height'                 => $w['height'],
 			'id'                     => $w['id'],
 			'in_catalog'             => $w['in_catalog'],
+			'featured'               => $w['featured'],
 			'is_editable'            => $w['is_editable'],
 			'name'                   => $w['name'],
 			'is_playable'            => $w['is_playable'],

--- a/fuel/app/classes/materia/widget/installer.php
+++ b/fuel/app/classes/materia/widget/installer.php
@@ -313,8 +313,9 @@ class Widget_Installer
 		else
 		{
 			// update
-			// Do not over-write the db's in_catalog flag
+			// Do not over-write the db's in_catalog and featured flag
 			if (isset($params['in_catalog'])) unset($params['in_catalog']);
+			if (isset($params['featured'])) unset($params['featured']);
 
 			$num = \DB::update('widget')
 				->set($params)

--- a/fuel/app/classes/materia/widget/manager.php
+++ b/fuel/app/classes/materia/widget/manager.php
@@ -12,7 +12,7 @@ class Widget_Manager
 	 *
 	 * @return array The information and metadata about the widget or widgets called for.
 	 */
-	static public function get_widgets($widget_ids=null, $type='featured')
+	static public function get_widgets($widget_ids=null, $type='catalog')
 	{
 		$widgets = [];
 		// =============== Get the requested widgets =================
@@ -40,6 +40,7 @@ class Widget_Manager
 					break;
 
 				case 'featured':
+					$query->where('featured', '1');
 				case 'catalog':
 				default:
 					$query->where('in_catalog', '1');

--- a/fuel/app/migrations/058_add_featured_to_widget.php
+++ b/fuel/app/migrations/058_add_featured_to_widget.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Fuel\Migrations;
+
+class Add_featured_to_widget
+{
+	public function up()
+	{
+		\DBUtil::add_fields(
+			'widget', // find the table that contains the assets.
+			[
+				'featured' => ['type' => 'enum', 'constraint' => "'0','1'", 'default' => '0'],
+			]
+		);
+
+		// Update featured field to match in_catalog values
+		\DB::update('widget')
+			->value('featured', \DB::expr('in_catalog'))
+			->execute();
+
+	}
+
+	public function down()
+	{
+		\DBUtil::drop_fields(
+			'widget',
+			['featured']
+		);
+	}
+}

--- a/fuel/app/tests/widgets/manager.php
+++ b/fuel/app/tests/widgets/manager.php
@@ -142,21 +142,32 @@ class Test_Widget_Manager extends \Basetest
 
 	public function test_get_all_widgets_featured()
 	{
+		$not_featured = $this->make_disposable_widget();
 		$not_in_catalog = $this->make_disposable_widget();
 		$not_playable = $this->make_disposable_widget();
 		$visible[] = $this->make_disposable_widget();
 		$visible[] = $this->make_disposable_widget();
 
-		// this shouldn't show up
+		// this shouldn't show up despite featured being true
 		$this->_as_super_user();
 		$args = $this->sample_widget_update_args($not_in_catalog->id, $not_in_catalog->clean_name);
 		$args->in_catalog = false;
+		$args->featured = true;
 		$msg = \Materia\Widget_Manager::update_widget($args);
 
-		// this shouldn't show up
+		// this shouldn't show up despite featured being true
 		$args = $this->sample_widget_update_args($not_playable->id, $not_playable->clean_name);
 		$args->is_playable = false;
+		$args->featured = true;
 		$msg = \Materia\Widget_Manager::update_widget($args);
+
+		// have to set featured to true for visible widgets, as it is false by default
+		foreach ($visible as $widget)
+		{
+			$args = $this->sample_widget_update_args($widget->id, $widget->clean_name);
+			$args->featured = true;
+			$msg = \Materia\Widget_Manager::update_widget($args);
+		}
 
 		$res = \Materia\Widget_Manager::get_widgets(null, 'featured');
 		self::assertCount(2, $res);
@@ -184,7 +195,7 @@ class Test_Widget_Manager extends \Basetest
 		$args->is_playable = false;
 		$msg = \Materia\Widget_Manager::update_widget($args);
 
-		$res = \Materia\Widget_Manager::get_widgets(null, 'featured');
+		$res = \Materia\Widget_Manager::get_widgets(null, 'catalog');
 		self::assertCount(2, $res);
 
 		self::assertEquals($visible[0]->id, $res[0]->id);
@@ -225,6 +236,7 @@ class Test_Widget_Manager extends \Basetest
 		$args->id = $id;
 		$args->clean_name = $clean_name;
 		$args->in_catalog = 1;
+		$args->featured = 0;
 		$args->is_editable = 1;
 		$args->is_scorable = 1;
 		$args->is_playable = 1;

--- a/src/components/catalog-card.jsx
+++ b/src/components/catalog-card.jsx
@@ -9,6 +9,7 @@ const CatalogCard = ({
 	id,
 	clean_name = '',
 	in_catalog = '0',
+	featured = '0',
 	name = '',
 	dir = '',
 	meta_data,
@@ -17,7 +18,7 @@ const CatalogCard = ({
 }) => {
 	// 'Featured' label
 	let featuredLabelRender = null
-	if (in_catalog === '1') {
+	if (featured === '1') {
 		featuredLabelRender = <div className='featured-label'>
 			<svg xmlns='http://www.w3.org/2000/svg'
 				width='18'

--- a/src/components/catalog-page.jsx
+++ b/src/components/catalog-page.jsx
@@ -7,7 +7,7 @@ import Catalog from './catalog'
 const CatalogPage = () => {
 	const { data: widgets, isLoading} = useQuery({
 		queryKey: 'catalog-widgets',
-		queryFn: apiGetWidgetsByType,
+		queryFn: () => apiGetWidgetsByType('catalog'),
 		staleTime: Infinity
 	})
 

--- a/src/components/catalog.jsx
+++ b/src/components/catalog.jsx
@@ -68,10 +68,10 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 			results = results.filter(w => re.test(w.name))
 		}
 
-		// if there are no filters set, take out the featured widgets (those with in_catalog = 1)
+		// if there are no filters set, take out the featured widgets (those with featured = 1)
 		// when no filter is present, a featured section appears already showing featured widgets
 		if (!isFiltered) {
-			results = results.filter(w => parseInt(w.in_catalog) !== 1)
+			results = results.filter(w => parseInt(w.featured) !== 1)
 		}
 
 		return [results, isFiltered]
@@ -189,7 +189,7 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 
 	let featuredWidgetsRender = null
 	if (!isFiltered && totalWidgets > 0 ) {
-		const featuredWidgetListRender = widgets.filter(w => w.in_catalog==='1')
+		const featuredWidgetListRender = widgets.filter(w => w.featured==='1')
 		.map(w => <CatalogCard {...w} key={w.id} />)
 		featuredWidgetsRender = (
 			<div className='widget-group'>

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -71,8 +71,8 @@ export const apiGetInstancesForUser = userId => {
 		.then(handleErrors)
 }
 
-export const apiGetWidgetsByType = () => {
-	return fetchGet('/api/json/widgets_get_by_type/', { body: `data=${formatFetchBody(['all'])}` })
+export const apiGetWidgetsByType = (type = 'all') => {
+	return fetchGet('/api/json/widgets_get_by_type/', { body: `data=${formatFetchBody([type])}` })
 }
 
 // Gets widget info


### PR DESCRIPTION
### This PR includes a migration.

Addresses #1657. Small update to the widget engine model to add a `featured` flag that determines whether widgets are displayed as "featured" in the catalog, replacing the erroneous filter mechanism that used `in_catalog`.

This allows complete catalog visibility to be determined by the `in_catalog` flag while using `featured` for the explicit purpose of highlighting featured widgets.

- Appends `featured` to the `widget` table and adds the associated property to the widget class
- Updates widget API endpoint to differentiate `in_catalog` and `featured`
- Updates catalog to filter and display widgets based on the new `featured` property instead of using `in_catalog`
- Updates tests to match.