### PR TITLE
Add User-Agent header to post requests being sent to the LMS.

### DIFF
--- a/fuel/app/classes/materia/widget/installer.php
+++ b/fuel/app/classes/materia/widget/installer.php
@@ -524,10 +524,14 @@ class Widget_Installer
 		{
 			throw new \Exception('Missing score module file');
 		}
-		if ( ! file_exists("$dir/_score-modules/test_score_module.php"))
-		{
-			throw new \Exception('Missing score module tests');
-		}
+		// for the most part the score module 'tests' were always just placeholders
+		//  that we meant to but never actually got around to fully implementing
+		// this would be required for backwards compatibility at best, but since there
+		//  are no tests practically this requirement is kind of meaningless
+		// if ( ! file_exists("$dir/_score-modules/test_score_module.php"))
+		// {
+		// 	throw new \Exception('Missing score module tests');
+		// }
 	}
 
 	public static function generate_install_params(array $manifest_data, string $package_file): array

--- a/fuel/app/modules/lti/classes/oauth.php
+++ b/fuel/app/modules/lti/classes/oauth.php
@@ -74,7 +74,7 @@ class Oauth
 			'http' => [
 				'method'  => 'POST',
 				'content' => $body,
-				'header'  => $request->to_header()."\r\nContent-Type: application/xml\r\n",
+				'header'  => $request->to_header()."\r\nContent-Type: application/xml\r\nUser-Agent: Materia-PHP-Server\r\n",
 			]
 		];
 


### PR DESCRIPTION
Closes #1670.

Adds 'User-Agent' header to LMS POST requests.

Removes score module test requirement from widget installer.