### PR TITLE
Use URL params to determine if a creator is embedded.

### DIFF
--- a/src/components/widget-creator-page.jsx
+++ b/src/components/widget-creator-page.jsx
@@ -5,18 +5,17 @@ import WidgetCreator from './widget-creator'
 import './widget-creator-page.scss'
 
 const EMBED = 'embed'
-const PREVIEW_EMBED = 'preview-embed'
 
-const getWidgetType = path => {
+const getWidgetType = () => {
+	const urlParams = new URLSearchParams(window.location.search)
 	switch(true) {
-		case path.includes('/embed/'): return EMBED
-		case path.includes('/preview-embed/'): return PREVIEW_EMBED
+		case !! urlParams.get('is_embedded'): return EMBED
 		default: return null
 	}
 }
 
 const WidgetCreatorPage = () => {
-	const type = getWidgetType(window.location.pathname)
+	const type = getWidgetType()
 	const pathParams = window.location.pathname.split('/')
 	const widgetID = pathParams[pathParams.length - 3].split('-')[0]
 	const instanceID = pathParams[pathParams.length - 1]
@@ -29,7 +28,7 @@ const WidgetCreatorPage = () => {
 
 	// Waits for window values to load from server then sets them
 	useEffect(() => {
-		if (type == EMBED || type == PREVIEW_EMBED) document.body.classList.add('embedded')
+		if (type == EMBED) document.body.classList.add('embedded')
 		waitForWindow()
 		.then(() => {
 			setState({
@@ -49,14 +48,15 @@ const WidgetCreatorPage = () => {
 
 	let headerRender = <Header />
 	// No header for embedded widgets
-	if ( type == EMBED || type == PREVIEW_EMBED ) headerRender = null
+	if (type == EMBED) headerRender = null
 
 	let bodyRender = (
 		<WidgetCreator
 			widgetId={state.widgetID}
 			instId={state.instanceID}
 			minHeight={state.widgetHeight}
-			minWidth={state.widgetWidth} />
+			minWidth={state.widgetWidth}
+			isEmbedded={type == EMBED} />
 	)
 
 	return (

--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -6,7 +6,7 @@ import NoPermission from './no-permission'
 import Alert from './alert'
 import { creator } from './materia-constants';
 
-const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
+const WidgetCreator = ({instId, widgetId, minHeight='', minWidth='', isEmbedded=false}) => {
 
 	/* =========== state information =========== */
 
@@ -485,7 +485,7 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 				}
 				switch (saveModeRef.current) {
 					case 'preview':
-						var url = `${window.BASE_URL}preview/${inst.id}`
+						var url = `${window.BASE_URL}${isEmbedded ? 'preview-embed' : 'preview'}/${inst.id}`
 						var popup = window.open(url)
 						setInstance(currentInstance => ({ ...currentInstance, id: inst.id }))
 						instIdRef.current = inst.id


### PR DESCRIPTION
Closes #1673.

Removes window location parsing logic from WidgetCreatorPage component in favor of using the '?is_embedded' URL parameter to determine whether a creator is embedded.

Adds new prop to WidgetCreator component to track whether a creator is embedded and use this to control the widget preview URL.

Currently this is probably only ever going to be used by the MWDK to omit unnecessary header components (see ucfopen/Materia-Widget-Dev-Kit#149).