### PR TITLE
Fixes S3 asset storage driver crashing on audio uploads.

### DIFF
--- a/app/storage/s3.py
+++ b/app/storage/s3.py
@@ -178,9 +178,13 @@ class S3AssetStorageDriver:
             Key=S3AssetStorageDriver.get_key_name(asset.id, "original"),
             ExtraArgs={"ContentType": asset.get_mime_type()},
         )
-        # Upload the thumbnail
-        thumbnail_buffer = io.BytesIO(file_bytes)
-        S3AssetStorageDriver.build_size(asset, "thumbnail", s3_client, thumbnail_buffer)
+
+        # If this is an image, create and upload a thumbnail as well
+        if asset.get_mime_type().split("/")[0] == "image":
+            thumbnail_buffer = io.BytesIO(file_bytes)
+            S3AssetStorageDriver.build_size(
+                asset, "thumbnail", s3_client, thumbnail_buffer
+            )
 
     @staticmethod
     def render(asset, size):


### PR DESCRIPTION
Fixes #1693.

Adds a quick mime type check to the S3 driver so it doesn't crash trying to generate thumbnails for audio files.