### PR TITLE
Keep url parameters in embedded creators after saving a new widget for the first time.

### DIFF
--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -509,7 +509,7 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth='', isEmbedded=
 
 						const parts = window.location.pathname.split('/');
 						parts[parts.length - 1] = inst.id;
-						window.history.replaceState(null, '', parts.join('/'));
+						window.history.replaceState(null, '', parts.join('/')+(isEmbedded ? '?is_embedded=true' : ''))
 
 						setInstance(currentInstance => ({ ...currentInstance, ...inst }))
 						apiGetQuestionSet(inst.id).then((qset) => {


### PR DESCRIPTION
Adds a one-liner to carry forward embedded creator URL parameters after saving a new widget instance for the first time.