### PR TITLE
Adds missing break statement to general error component

### DIFF
--- a/src/components/lti/error-general.jsx
+++ b/src/components/lti/error-general.jsx
@@ -79,6 +79,7 @@ const ErrorGeneral = () => {
                 <p>Materia couldn't complete this operation because of a session caching issue.</p>
                 <p>This almost certainly isn't because of anything you did. If possible, please report the issue to support.</p>
             </section>
+            break;
         default:
             content =
                 <section id="error-container">


### PR DESCRIPTION
Fixes #1697 

As per title. There was a missing break statement from changes a few weeks ago. This PR adds in that break statement. 