### PR TITLE
Add null alternative text on decorative images

### DIFF
--- a/src/components/catalog-card.jsx
+++ b/src/components/catalog-card.jsx
@@ -63,7 +63,7 @@ const CatalogCard = ({
 				</div>
 
 				<div className='img-holder'>
-					<img src={iconUrl('/widget/', dir, 275)} />
+					<img src={iconUrl('/widget/', dir, 275)} alt=""/>
 				</div>
 
 				<div className='widget-info'>

--- a/src/components/catalog.jsx
+++ b/src/components/catalog.jsx
@@ -104,7 +104,7 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 	let searchCloseRender = null
 	if (state.searchText) {
 		searchCloseRender = (
-			<button className='search-close'
+			<button className='search-close' title='close search'
 				tabIndex='0'
 				onClick={ () => { setState({...state, searchText: ''}) } } />
 		)

--- a/src/components/detail-carousel.jsx
+++ b/src/components/detail-carousel.jsx
@@ -311,13 +311,13 @@ const DetailCarousel = ({widget, widgetHeight=''}) => {
 	screenshotData.screenshots.forEach((screenshot, index) => {
 		screenshotElements.push(
 			<div key={index}>
-				<img src={screenshot.full} />
+				<img src={screenshot.full} alt=""/>
 				<div className='screenshot-drag-cover'></div>
 				<h3>Screenshot {index + 1} of {screenshotData.numScreenshots}</h3>
 			</div>
 		)
 		screenshotDotElements.push(
-			<button key={index}
+			<button key={index} title={`show screenshot ${index + 1}`}
 				className={`pic-dot ${selectionData.selectedImage.num === index + 1 ? 'selected' : ''}`}
 				onClick={() => setSelectionData({...selectionData, selectedImage: {num: index + 1, reset: true}})}>
 			</button>
@@ -350,7 +350,7 @@ const DetailCarousel = ({widget, widgetHeight=''}) => {
 			}
 			else demoRender = (
 				<>
-					<img style={{minHeight: demoData.demoHeight}} src={screenshotData.screenshots[0]?.full}/>
+					<img style={{minHeight: demoData.demoHeight}} src={screenshotData.screenshots[0]?.full} alt=""/>
 					<div id='demo-cover'
 						className={`${demoData.demoLoading ? 'loading' : ''}`}
 						style={{backgroundImage: `url(${screenshotData.screenshots[0]?.full})`}} >

--- a/src/components/extra-attempts-row.jsx
+++ b/src/components/extra-attempts-row.jsx
@@ -34,7 +34,7 @@ const ExtraAttemptsRow = ({extraAttempt, user, onChange}) => {
 					X
 				</button>
 				<div className='user'>
-					<img className="avatar" src={user.avatar} />
+					<img className="avatar" src={user.avatar} alt=""/>
 
 					<span className='user_name'>
 						{`${user.first_name} ${user.last_name}`}

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -120,7 +120,9 @@ const Header = ({
 						<a href='/profile' aria-label='Visit your profile page.'>{`${user.first_name} ${user.last_name}`}</a>
 						<a onClick={logoutUser}>Logout</a>
 					</div>
-					<a href='/profile' aria-label='User avatar. Click to visit your profile page.'><img src={user.avatar} onClick={showUserOptions}/></a>
+					<a href='/profile' aria-label='User avatar. Click to visit your profile page.'>
+						<img src={user.avatar} onClick={showUserOptions} alt=""/>
+					</a>
 				</>
 			)
 

--- a/src/components/homepage.jsx
+++ b/src/components/homepage.jsx
@@ -27,7 +27,7 @@ const Homepage = () => (
 		</section>
 
 		<section className='get_started'>
-		<img src="/static/img/social-ucf-open.png"/>
+			<img src="/static/img/social-ucf-open.png" alt=""/>
 
 			<div className='get_started_content'>
 					<h1 className='subHeader'> Materia is Open Source! </h1>

--- a/src/components/my-widgets-collaborate-user-row.jsx
+++ b/src/components/my-widgets-collaborate-user-row.jsx
@@ -179,7 +179,7 @@ const CollaborateUserRow = ({user, perms, myPerms, isCurrentUser, onlyOneFullPer
 			</button>
 
 			<div className='about'>
-				<img className='avatar' src={user.avatar} />
+				<img className='avatar' src={user.avatar} alt=""/>
 
 				<span className={`name ${user.is_owner ? 'user-match-owner' : user.is_student ? 'user-match-student' : ''}`}>
 					{`${user.first_name} ${user.last_name}`}

--- a/src/components/my-widgets-instance-card.jsx
+++ b/src/components/my-widgets-instance-card.jsx
@@ -35,7 +35,7 @@ const MyWidgetsInstanceCard = ({inst, indexVal, hidden = false, selected = false
 			className={classes.join(' ')}
 			onClick={clickHandler}
 			onKeyDown={keyInputHandler}>
-			<img className='icon' src={img} />
+			<img className='icon' src={img} alt=""/>
 			<ul>
 				<li className='title searchable'
 					dangerouslySetInnerHTML={{ __html: nameTextRender }}>

--- a/src/components/notifications.jsx
+++ b/src/components/notifications.jsx
@@ -201,7 +201,7 @@ const Notifications = ({user}) => {
 				onMouseEnter={() => showDeleteButton(index)}
 				onMouseLeave={hideDeleteButton}
 				>
-				<img className='senderAvatar' src={notification.avatar} />
+				<img className='senderAvatar' src={notification.avatar} alt=""/>
 				<div className='notice_right_side'>
 					<div dangerouslySetInnerHTML={{__html: `<p class='subject'>${notification.subject}</p>`}}></div>
 					{ grantAccessDropdown }
@@ -211,6 +211,7 @@ const Notifications = ({user}) => {
 				<img src="/static/img/icon-cancel.svg"
 					className={`noticeClose ${showDeleteBtn == index ? 'show' : ''}`}
 					onClick={() => {removeNotification(index)}}
+					alt=""
 				/>
 				<p className='notif-error'>{errorMsg.notif_id == notification.id ? errorMsg.msg : ''}</p>
 			</div>

--- a/src/components/profile-page.jsx
+++ b/src/components/profile-page.jsx
@@ -130,7 +130,7 @@ const ProfilePage = () => {
 			<section className="page user">
 				<ul className="main_navigation" role="menu">
 					<div className="avatar_big">
-						<img src={currentUser.avatar} />
+						<img src={currentUser.avatar} alt=""/>
 					</div>
 					<ul>
 						<li className="selected_profile">

--- a/src/components/settings-page.jsx
+++ b/src/components/settings-page.jsx
@@ -147,7 +147,7 @@ const SettingsPage = () => {
 			<section className="page settings">
 				<ul className="main_navigation" role="menu">
 					<div className="avatar_big">
-						<img src={currentUser.avatar} />
+						<img src={currentUser.avatar} alt=""/>
 					</div>
 					<ul>
 						<li className="profile">

--- a/src/components/support-selected-instance.jsx
+++ b/src/components/support-selected-instance.jsx
@@ -321,7 +321,7 @@ const SupportSelectedInstance = ({inst, currentUser, onCopySuccess, embed = fals
 				{ breadcrumbContainer }
 				<div className='instance-management'>
 					<div className='header'>
-					<img src={iconUrl('/widget/', updatedInst.widget.dir, 60)} />
+					<img src={iconUrl('/widget/', updatedInst.widget.dir, 60)} alt=""/>
 					<input type='text' value={updatedInst.name}
 						onChange={event => handleChange('name', event.target.value)}
 					/>

--- a/src/components/user-admin-instance-available.jsx
+++ b/src/components/user-admin-instance-available.jsx
@@ -32,7 +32,7 @@ const UserAdminInstanceAvailable = ({instance, index, onCopySuccess, currentUser
 			<div className={`clickable widget-title ${instanceState.manager ? 'hidden' : ''}`}
 		onClick={() => setInstanceState(instanceState => ({...instanceState, expanded: !instanceState.expanded, manager: false}))}>
 				<span className='img-holder'>
-					<img src={iconUrl('/widget/', instance.widget.dir, 275)} />
+					<img src={iconUrl('/widget/', instance.widget.dir, 275)} alt=""/>
 				</span>
 				<span className='title-holder'>
 					<div className='title'>

--- a/src/components/user-admin-instance-played.jsx
+++ b/src/components/user-admin-instance-played.jsx
@@ -18,7 +18,7 @@ const UserAdminInstancePlayed = ({play, index}) => {
 		<li key={index} className={`instance ${instanceState.expanded ? 'expanded' : ''}`} onClick={() => setInstanceState(instanceState => ({...instanceState, expanded: !instanceState.expanded}))}>
 			<div className='clickable widget-title'>
 				<span className='img-holder'>
-					<img src={iconUrl('/widget/', play.widget_icon, 275)} />
+					<img src={iconUrl('/widget/', play.widget_icon, 275)} alt=""/>
 				</span>
 				<span className='title-holder'>
 					<div className='title'>

--- a/src/components/widget-admin-list-card.jsx
+++ b/src/components/widget-admin-list-card.jsx
@@ -119,7 +119,7 @@ const WidgetListCard = ({widget = null}) => {
         <li key={state.widget.id}>
             <div className="clickable widget-title" onClick={handleWidgetClick}>
                 <span className="img-holder">
-                    <img src={state.widget.icon}/>
+                    <img src={state.widget.icon} alt=""/>
                 </span>
                 <span className="title">{state.widget.name}</span>
             </div>


### PR DESCRIPTION
As per #1700, many of the decorative images lack alternative text. This PR adds null alt text in many of those places. 

There are a few places I missed. Namely, buttons and iframes that are missing names. Mostly because I don't know enough about the structure of Materia to know what they do and how they should be labeled. For instance, `src/components/guide-page.jsx:38`. 