### PR TITLE
Improves play session loading in user admin panel

### DIFF
--- a/app/api/views/playsessions.py
+++ b/app/api/views/playsessions.py
@@ -33,7 +33,9 @@ class PlaySessionPagination(PageNumberWithTotalPagination):
     max_page_size = 100
 
     def get_page_size(self, request):
-        if request.query_params.get("include_activity"):
+        if request.query_params.get("admin_activity"):
+            return 50
+        elif request.query_params.get("include_activity"):
             return 8
         return self.page_size
 

--- a/src/components/hooks/useGetPlaySessions.jsx
+++ b/src/components/hooks/useGetPlaySessions.jsx
@@ -4,7 +4,7 @@ import { apiGetUserPlaySessions } from '../../util/api'
 
 // facilitates paginated requests for widget instances. Returns a flat list with some handlers associated with the query.
 // will default to the current user ("me"), but allows requests for another user id if passed as a param on init or via the exposed setUser method.
-export default function useGetPlaySessions(user, autofetch) {
+export default function useGetPlaySessions(user, autofetch, admin_activity) {
 
 	const [errorState, setErrorState] = useState(false)
 
@@ -27,7 +27,7 @@ export default function useGetPlaySessions(user, autofetch) {
 	}
 
 	const getPlaySessions = ({pageParam = 1}) => {
-		return apiGetUserPlaySessions(user, pageParam)
+		return apiGetUserPlaySessions(user, pageParam, admin_activity)
 	}
 
 	const {

--- a/src/components/user-admin-page.scss
+++ b/src/components/user-admin-page.scss
@@ -334,6 +334,12 @@
 
 			&.instances {
 
+				button.show_more_activity {
+					display: block;
+					margin: 10px auto;
+					padding: 8px 20px;
+				}
+
 				ul {
 					padding: 0;
 					flex-direction: row;

--- a/src/components/user-admin-selected.jsx
+++ b/src/components/user-admin-selected.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react'
-import { useQuery, useQueryClient } from 'react-query'
+import React, { useState, useEffect, useRef } from 'react'
+import { useQueryClient } from 'react-query'
 import UserAdminInstanceAvailable from './user-admin-instance-available'
 import UserAdminInstancePlayed from './user-admin-instance-played'
 import useInstanceList from './hooks/useInstanceList'
@@ -11,8 +11,17 @@ const UserAdminSelected = ({selectedUser, currentUser, roles, onReturn}) => {
 	const queryClient = useQueryClient()
 	const [updatedUser, setUpdatedUser] = useState({...selectedUser})
 	const instancesOwned = useInstanceList(updatedUser.id)
-	const userLogs = useGetPlaySessions(updatedUser.id, true)
+	const userLogs = useGetPlaySessions(updatedUser.id, false, true)
 	const [isSuper, setIsSuper] = useState(false)
+	const scrollAnchorRef = useRef(null)
+	const scrollToIndex = useRef(null)
+
+	useEffect(() => {
+		if (scrollToIndex.current !== null) {
+			scrollAnchorRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+			scrollToIndex.current = null
+		}
+	}, [userLogs.plays?.length])
 
 	const [errorText, setErrorText] = useState('')
 	const [successText, setSuccessText] = useState('')
@@ -70,14 +79,28 @@ const UserAdminSelected = ({selectedUser, currentUser, roles, onReturn}) => {
 	}
 
 	let instancesPlayed = <span>Play history loading...</span>
-	if (!userLogs.isFetching) {
-		if (!!userLogs.plays && userLogs.plays.length > 0) {
-			instancesPlayed = userLogs.plays?.map((play, index) => {
-				return (<UserAdminInstancePlayed play={play} key={index} />)
-			})
-		} else {
-			instancesPlayed = <span>This user has not played any widgets.</span>
+	let loadMoreButton = null
+	if (!!userLogs.plays && userLogs.plays.length > 0) {
+		instancesPlayed = userLogs.plays?.map((play, index) => {
+			return (
+				<React.Fragment key={index}>
+					{index === scrollToIndex.current && <li ref={scrollAnchorRef} />}
+					<UserAdminInstancePlayed play={play} />
+				</React.Fragment>
+			)
+		})
+		if (userLogs.hasNextPage) {
+			loadMoreButton = (
+				<button className="action_button show_more_activity" onClick={() => {
+					scrollToIndex.current = userLogs.plays.length
+					userLogs.fetchNextPage()
+				}}>
+					{userLogs.isFetching ? <span>Loading...</span> : <span>Show more</span>}
+				</button>
+			)
 		}
+	} else if (!userLogs.isFetching) {
+		instancesPlayed = <span>This user has not played any widgets.</span>
 	}
 
 	let suRender = null
@@ -157,6 +180,7 @@ const UserAdminSelected = ({selectedUser, currentUser, roles, onReturn}) => {
 					<ul>
 						{ instancesPlayed }
 					</ul>
+					{ loadMoreButton }
 				</div>
 			</div>
 		</section>

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -604,7 +604,8 @@ export const apiCanBePublishedByCurrentUser = (widgetId) => {
 /** Controller_Api_User */
 
 export const apiGetUserPlaySessions = (user, pageParam = 1, admin_activity = false) => {
-	return handleRequest('GET', `/api/play-sessions/?user=${user}&include_activity=true&admin_activity=${admin_activity}&page=${pageParam}`)
+	const activityParam = admin_activity ? 'admin_activity=true' : 'include_activity=true'
+	return handleRequest('GET', `/api/play-sessions/?user=${user}&${activityParam}&page=${pageParam}`)
 }
 
 export const apiUpdateUserSettings = (settings) => {

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -603,8 +603,8 @@ export const apiCanBePublishedByCurrentUser = (widgetId) => {
 
 /** Controller_Api_User */
 
-export const apiGetUserPlaySessions = (user, pageParam = 1) => {
-	return handleRequest('GET', `/api/play-sessions/?user=${user}&include_activity=true&page=${pageParam}`)
+export const apiGetUserPlaySessions = (user, pageParam = 1, admin_activity = false) => {
+	return handleRequest('GET', `/api/play-sessions/?user=${user}&include_activity=true&admin_activity=${admin_activity}&page=${pageParam}`)
 }
 
 export const apiUpdateUserSettings = (settings) => {


### PR DESCRIPTION
Fixes issue #1692

## Problem
The user admin panel auto-fetches all play session records on page load. With include_activity enabled, page size is only 8 records, resulting in many small API requests that are slow for users with large play histories.

 ## Solution
  - Added admin_activity query param that increases page size to 50
  - Replaced auto-fetch with manual "Show more" button
  - Added smooth scrollIntoView to keep new records in view when loading more