### PR TITLE
Fixes HTML entities displaying as raw text

### DIFF
--- a/app/core/templates/react.html
+++ b/app/core/templates/react.html
@@ -68,7 +68,7 @@
 					{% if value|get_type == "NoneType" %}
 						var {{key}} = null;
 					{% elif value|get_type == "str" %}
-						var {{key}} = '{{value}}';
+						var {{key}} = '{{value|escapejs}}';
 					{% elif value|get_type == "bool" and value %}
 						var {{key}} = true;
 					{% elif value|get_type == "bool" and not value %}


### PR DESCRIPTION
Fixes issue #1691

## Problem
Django's `{{ value }}` auto-escaping converts `&` to `&amp;`, which is correct for HTML contexts. But inside `<script>` tags the browser does not decode HTML entities, so JavaScript receives the literal string `&amp;` instead of `&`.

## Solution
Replace `{{ value }}` with `{{ value|escapejs }}`. This filter uses JavaScript-native escape sequences that the JS engine properly interprets, while still protecting against code injection.