### PR TITLE
Handles empty semesters param in export_playdata endpoint

### DIFF
--- a/app/api/tests/test_widget_instance_views.py
+++ b/app/api/tests/test_widget_instance_views.py
@@ -1540,6 +1540,19 @@ class TestInstanceExportPlaydata(WidgetInstanceViewSetTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_export_with_empty_semesters_param(self):
+        """Export should handle empty semesters param without error"""
+        self.client.force_authenticate(user=self.author_user)
+        response = self.client.get(
+            f"/api/instances/{self.author_instance.id}/export_playdata/",
+            {
+                "type": "Questions and Answers",
+                "semesters": "",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_export_requires_type_param(self):
         self.client.force_authenticate(user=self.author_user)
         response = self.client.get(

--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -577,7 +577,7 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
         is_student = PermService.user_is_student(request.user)
 
         queryset = LogPlay.objects.none()
-        semesters = semester_ids.split(",")
+        semesters = [s for s in semester_ids.split(",") if s]
 
         # preconstruct the queryset to pass to the export service
         if export_type != "storage":


### PR DESCRIPTION
Fixes Sentry error: https://university-of-central-flori-pk.sentry.io/issues/7450925333/?project=4510750267473920&query=is%3Aunresolved%20issue.category%3A%5Berror%2Coutage%5D&referrer=issue-stream

## Problem
When `semesters` query param was empty, `"".split(",")` returns `[""]` instead of `[]`, causing the endpoint to crash trying to unpack an empty string into `[year, term]`.

## Testing
Added `test_export_with_empty_semesters_param` to cover this case.