### PR TITLE
skips access window check for widget previews

### DIFF
--- a/app/core/services/widget_play_services.py
+++ b/app/core/services/widget_play_services.py
@@ -104,7 +104,7 @@ class WidgetPlayValidationService:
             return WidgetPlayValidationService.INVALID_NOT_PLAYABLE
 
         instance_availability = instance.availability_status()
-        if not instance_availability["is_open"]:
+        if not is_preview and not instance_availability["is_open"]:
             return WidgetPlayValidationService.INVALID_NOT_YET_OPEN
 
         if not has_guest_access:


### PR DESCRIPTION
Fixes #1716

## Summary
Previews were incorrectly blocked by open/close date access window settings the same way a regular play would be. Updated the validation logic to skip the access window check for previews.

## Testing
Manual testing confirmed previews are no longer blocked by access window settings.