### PR TITLE
Player setHeight sends frameResize postMessage in LTI contexts

### DIFF
--- a/src/components/widget-player.jsx
+++ b/src/components/widget-player.jsx
@@ -10,6 +10,7 @@ import LoadingIcon from './loading-icon'
 import './widget-player.scss'
 
 const HEARTBEAT_INTERVAL = 15000 // 15 seconds for each heartbeat
+const MIN_WIDGET_HEIGHT = 640
 
 const initLogs = () => ({ play: [], storage: [] })
 
@@ -121,6 +122,9 @@ const WidgetPlayer = ({instanceId, playId, minHeight=0, minWidth=0,showFooter=tr
 	const frameRef = useRef(null)
 	const scoreScreenUrlRef = useRef(null)
 	const darkModeRef = useRef(false)
+
+	const urlParams = new URLSearchParams(window.location.search)
+	const hasLti = urlParams.has('token')
 
 	/*********************** queries ***********************/
 
@@ -381,6 +385,12 @@ const WidgetPlayer = ({instanceId, playId, minHeight=0, minWidth=0,showFooter=tr
 			setStartTime(new Date().getTime())
 			_sendToWidget('initWidget',	[qset, convertedInstance, window.BASE_URL, window.MEDIA_URL])
 			setPlayState('playing')
+
+			// if embedded in an LTI context, preemptively set the height of the player frame
+			if (hasLti) {
+				const initHeight = inst.widget.height != 0 ? inst.widget.height : MIN_WIDGET_HEIGHT
+				_setHeight(initHeight)
+			}
 		}
 	}
 
@@ -545,10 +555,8 @@ const WidgetPlayer = ({instanceId, playId, minHeight=0, minWidth=0,showFooter=tr
 		let desiredHeight = Math.max(h, min_h)
 		setAttributes((oldData) => ({...oldData, height: `${desiredHeight}px`}))
 
-		
-		const params = new URLSearchParams(window.location.search)
 		// The presence of the token param indicates an LTI play. Send the frameResize postMessage to the parent frame (the LMS)
-		if (params.get('token')) {
+		if (hasLti) {
 			window.parent.postMessage(
 			{
 				subject: 'lti.frameResize',

--- a/src/components/widget-player.jsx
+++ b/src/components/widget-player.jsx
@@ -368,7 +368,7 @@ const WidgetPlayer = ({instanceId, playId, minHeight=0, minWidth=0,showFooter=tr
 		}
 		else if( ! ['react-devtools-content-script', 'react-devtools-bridge', 'react-devtools-inject-backend'].includes(e.data.source)) {
 			throw new Error(
-				`Post message Origin does not match. Expected: ${expectedOrigin}, Actual: ${origin}`
+				`Post message Origin does not match. Expected: ${window.BASE_URL} || ${window.STATIC_CROSSDOMAIN}, Actual: ${origin}`
 			)
 		}
 	}
@@ -544,6 +544,19 @@ const WidgetPlayer = ({instanceId, playId, minHeight=0, minWidth=0,showFooter=tr
 		const min_h = inst.widget.height
 		let desiredHeight = Math.max(h, min_h)
 		setAttributes((oldData) => ({...oldData, height: `${desiredHeight}px`}))
+
+		
+		const params = new URLSearchParams(window.location.search)
+		// The presence of the token param indicates an LTI play. Send the frameResize postMessage to the parent frame (the LMS)
+		if (params.get('token')) {
+			window.parent.postMessage(
+			{
+				subject: 'lti.frameResize',
+    			height: desiredHeight + 60, // add 60 to desiredHeight for footer
+			},
+			'*'
+			)
+		}
 	}
 
 	const _setVerticalScroll = location => {


### PR DESCRIPTION
The `_setHeight` method in the player frame now checks for LTI context (via the `?token=` URL param) and sends a `lti.frameResize` postMessage to `window.parent` to request iframe resizing. This is in accordance with [Canvas's postMessage API](https://developerdocs.instructure.com/services/canvas/external-tools/lti/file.lti_window_post_message#lti.frameresize)

Additionally, `_setHeight` is called upon widget init in LTI contexts, to force a resize of the parent iframe. This default call uses the widget's `height` value from the `install.yaml` (if not 0) and `640px` otherwise. This _does_ mean that certain responsive widgets may benefit from calling `setHeight` to ensure the frame renders at a minimum height above 640px if the widget would benefit from a larger value.