### PR TITLE
Modernize redis container in docker compose orchestration.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       - backend
 
   redis:
-    image: redis:3.2
+    image: redis:8.8.0
     ports:
       - "6379:6379"
     networks:


### PR DESCRIPTION
Closes #1736.

Bumps `redis` container image from `redis:3.2` to `redis:8.8.0`.