### PR TITLE
Adds graceful fallback for invalid play IDs passed as token params

### DIFF
--- a/app/core/mixins.py
+++ b/app/core/mixins.py
@@ -5,6 +5,7 @@ from core.services.widget_play_services import WidgetPlayValidationService
 from core.utils.context_util import ContextUtil
 from django.contrib.auth.mixins import AccessMixin
 from django.http import Http404, HttpRequest, HttpResponse
+from pylti1p3.exception import LtiException
 
 logger = logging.getLogger(__name__)
 
@@ -118,7 +119,14 @@ class MateriaWidgetPlayProcessor:
             if not instance:
                 raise Http404("A widget instance with this ID does not exist.")
             is_embedded = kwargs.get("is_embed", False)
-            validation = self.get_validation(request, instance)
+            try:
+                validation = self.get_validation(request, instance)
+            except LtiException:
+                from core.services.widget_play_services import (
+                    WidgetPlayValidationService,
+                )
+
+                validation = WidgetPlayValidationService.INVALID_RECOVERY_TOKEN
 
             request._widget_play_state = {
                 "instance": instance,

--- a/app/core/services/widget_play_services.py
+++ b/app/core/services/widget_play_services.py
@@ -82,6 +82,7 @@ class WidgetPlayValidationService:
     INVALID_DRAFT_NOT_PLAYABLE = "draft_not_playable"
     INVALID_RETIRED_WIDGET = "widget_retired"
     INVALID_NO_ATTEMPTS = "no_attempts"
+    INVALID_RECOVERY_TOKEN = "bad_recovery_token"
     VALID_WITH_PRE_EMBED = "pre_embed"
     VALID = "valid"
 

--- a/app/core/views/widget.py
+++ b/app/core/views/widget.py
@@ -129,8 +129,11 @@ class WidgetPlayView(
                 )
 
         elif LTILaunchService.is_recovery_launch(request):
-            play = LogPlay.objects.get(pk=request.GET.get("token"))
-            context_id = play.context_id
+            play = LogPlay.objects.filter(pk=request.GET.get("token")).first()
+            if play:
+                context_id = play.context_id
+            else:
+                raise LtiException("Invalid token for context id recovery")
 
         # Check if this instance is a guest/demo instance
         has_guest_access = instance.guest_access
@@ -475,6 +478,9 @@ def _create_player_context(
     is_preview: bool = False,
     is_embedded: bool = False,
 ):
+    if validation == WidgetPlayValidationService.INVALID_RECOVERY_TOKEN:
+        return _create_lti_error_page(request, "error_recovery_token")
+
     # Check if embed only widget
     if validation == WidgetPlayValidationService.INVALID_EMBEDDED_ONLY:
         return _create_embedded_only_page(request, instance)
@@ -691,6 +697,20 @@ def _create_lti_success_page(
             "USER_ID": request.user.id,
         },
         js_resources=settings.JS_GROUPS["open-preview"],
+        css_resources=settings.CSS_GROUPS["lti"],
+        request=request,
+    )
+
+
+def _create_lti_error_page(request: HttpRequest, error_type: str):
+    return ContextUtil.create(
+        title="Widget Embed Error",
+        page_type="lti-error",
+        js_globals={
+            "TITLE": "There was a problem with this embedded content.",
+            "ERROR_TYPE": error_type,
+        },
+        js_resources=settings.JS_GROUPS["lti-error"],
         css_resources=settings.CSS_GROUPS["lti"],
         request=request,
     )

--- a/app/lti/services/launch.py
+++ b/app/lti/services/launch.py
@@ -278,7 +278,7 @@ class LTILaunchService:
         """
         Returns the associated LtiPlayState model instance for a given play ID.
         """
-        play = LogPlay.objects.get(pk=play_id)
+        play = LogPlay.objects.filter(pk=play_id).first()
         if play:
             launch = LtiPlayState.objects.filter(play_id=play.id).first()
             return launch

--- a/src/components/lti/error-general.jsx
+++ b/src/components/lti/error-general.jsx
@@ -2,104 +2,113 @@ import React, { useEffect, useState } from 'react'
 import SupportInfo from '../support-info'
 
 const ErrorGeneral = () => {
-    const [title, setTitle] = useState('')
-    const [errorType, setErrorType] = useState('')
+	const [title, setTitle] = useState('')
+	const [errorType, setErrorType] = useState('')
 
-    useEffect(() => {
-        if (window.TITLE) {
-            setTitle(window.TITLE)
-        }
-    }, [window.TITLE])
+	useEffect(() => {
+		if (window.TITLE) {
+			setTitle(window.TITLE)
+		}
+	}, [window.TITLE])
 
-    useEffect(() => {
-        if (window.ERROR_TYPE) {
-            setErrorType(window.ERROR_TYPE)
-        }
-    }, [window.ERROR_TYPE])
+	useEffect(() => {
+		if (window.ERROR_TYPE) {
+			setErrorType(window.ERROR_TYPE)
+		}
+	}, [window.ERROR_TYPE])
 
-    let content = null;
+	let content = null;
 
-    switch (errorType)
-    {
-        case 'error_unknown_assignment':
-            content =
-                <section id="error-container">
-                    <h4>Error type: Unknown Assignment</h4>
-                    <p>This Materia assignment hasn't been setup correctly in the LMS.</p>
-	                <p>Your instructor will need to complete the setup process.</p>
-                </section>
-            break;
-        case 'error_unknown_user':
-            content =
-                <section id="error-container">
-                    <h4>Error type: Unknown User</h4>
-                    <p>Materia cannot determine who you are using the information provided by the LMS.</p>
-                    <p>This may occur if you are using a non-standard account or if the LMS is missing information about who you are.</p>
-                    <p>If this message persists, contact support.</p>
-                </section>
-            break;
-        case 'error_launch_validation':
-            content =
-                <section id="error-container">
-                    <h4>Error type: Launch Validation Failed</h4>
-                    <p>The launch information provided by the LMS failed validation.</p>
-                    <p>Try accessing the tool again without using the back button. If prompted to re-submit page data, try leaving the page and re-selecting the activity.</p>
-                    <p>If this message persists, contact support.</p>
-                </section>
-            break;
-        case 'error_autoplay_misconfigured':
-            content =
-                <section id="error-container">
-                    <h4>Error type: Autoplay Misconfigured</h4>
-                    <p>This Materia assignment hasn't been setup correctly in the system.</p>
-                    <p>Non-autoplaying widgets can not be used as graded assignments.</p>
-                </section>
-            break;
-        case 'error_lti_guest_mode':
-            content =
-                <section id="error-container">
-                    <h4>Error type: Guest Mode Enabled</h4>
-                    <p>This assignment has guest mode enabled.</p>
-                    <p>This assignment can only record scores anonymously and therefore cannot be played as an embedded assignment.</p>
-                    <p>Your instructor will need to disable guest mode or provide a link to play as a guest.</p>
-                </section>
-            break;
-        case 'error_invalid_oauth_request':
-            content =
-                <section id="error-container">
-                    <h4>Error type: Invalid Oauth Request</h4>
-                    <p>Something went wrong when Materia tried to authenticate you with information from the LMS.</p>
-                    <p>We recommend contacting support:</p>
-                </section>
-            break;
-        case 'error_launch_recovery':
-            content =
-            <section id="error-container">
-                <h4>Error type: Launch Recovery Failure</h4>
-                <p>Materia couldn't complete this operation because of a session caching issue.</p>
-                <p>This almost certainly isn't because of anything you did. If possible, please report the issue to support.</p>
-            </section>
-            break;
-        default:
-            content =
-                <section id="error-container">
-                    <h4>Error type: General Error</h4>
-                    <p>An error occurred.</p>
-                    <p>If you need help accessing this tool, contact support.</p>
-                </section>
-            break;
-    }
+	switch (errorType)
+	{
+		case 'error_unknown_assignment':
+			content =
+				<section id="error-container">
+					<h4>Error type: Unknown Assignment</h4>
+					<p>This Materia assignment hasn't been setup correctly in the LMS.</p>
+					<p>Your instructor will need to complete the setup process.</p>
+				</section>
+			break;
+		case 'error_unknown_user':
+			content =
+				<section id="error-container">
+					<h4>Error type: Unknown User</h4>
+					<p>Materia cannot determine who you are using the information provided by the LMS.</p>
+					<p>This may occur if you are using a non-standard account or if the LMS is missing information about who you are.</p>
+					<p>If this message persists, contact support.</p>
+				</section>
+			break;
+		case 'error_launch_validation':
+			content =
+				<section id="error-container">
+					<h4>Error type: Launch Validation Failed</h4>
+					<p>The launch information provided by the LMS failed validation.</p>
+					<p>Try accessing the tool again without using the back button. If prompted to re-submit page data, try leaving the page and re-selecting the activity.</p>
+					<p>If this message persists, contact support.</p>
+				</section>
+			break;
+		case 'error_autoplay_misconfigured':
+			content =
+				<section id="error-container">
+					<h4>Error type: Autoplay Misconfigured</h4>
+					<p>This Materia assignment hasn't been setup correctly in the system.</p>
+					<p>Non-autoplaying widgets can not be used as graded assignments.</p>
+				</section>
+			break;
+		case 'error_lti_guest_mode':
+			content =
+				<section id="error-container">
+					<h4>Error type: Guest Mode Enabled</h4>
+					<p>This assignment has guest mode enabled.</p>
+					<p>This assignment can only record scores anonymously and therefore cannot be played as an embedded assignment.</p>
+					<p>Your instructor will need to disable guest mode or provide a link to play as a guest.</p>
+				</section>
+			break;
+		case 'error_invalid_oauth_request':
+			content =
+				<section id="error-container">
+					<h4>Error type: Invalid Oauth Request</h4>
+					<p>Something went wrong when Materia tried to authenticate you with information from the LMS.</p>
+					<p>We recommend contacting support:</p>
+				</section>
+			break;
+		case 'error_launch_recovery':
+			content =
+			<section id="error-container">
+				<h4>Error type: Launch Recovery Failure</h4>
+				<p>Materia couldn't complete this operation because of a session caching issue.</p>
+				<p>This almost certainly isn't because of anything you did. If possible, please report the issue to support.</p>
+			</section>
+			break;
+		case 'error_recovery_token':
+			content =
+			<section id="error-container">
+				<h4>Error type: Invalid Recovery Token</h4>
+				<p>Materia couldn't recover launch data from the token provided.</p>
+				<p>The URL for this activity may have been malformed. If possible, try launching the activity from your LMS again.</p>
+				<p>If the issue persists, contact support.</p>
+			</section>
+			break;
+		default:
+			content =
+				<section id="error-container">
+					<h4>Error type: General Error</h4>
+					<p>An error occurred.</p>
+					<p>If you need help accessing this tool, contact support.</p>
+				</section>
+			break;
+	}
 
-    return <>
-        <header>
-            <h1>{title}</h1>
-            <div id="logo"></div>
-        </header>
+	return <>
+		<header>
+			<h1>{title}</h1>
+			<div id="logo"></div>
+		</header>
 
-        {content}
+		{content}
 
-        <SupportInfo/>
-    </>
+		<SupportInfo/>
+	</>
 }
 
 export default ErrorGeneral


### PR DESCRIPTION
Resolves #1734 

Updates some ORM queries to use `filter().first()` instead of `get()`.

Adds error handling to validation and preprocessing elements of the widget play view to pass a new `INVALID_RECOVERY_TOKEN` validation state and create an appropriate context object.