### PR TITLE
Prevent crash in widget catalog if any widgets are missing features or supported data.

### DIFF
--- a/src/components/catalog.jsx
+++ b/src/components/catalog.jsx
@@ -50,7 +50,7 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 			results = results.filter(w => {
 				const {features, supported_data, accessibility_keyboard, accessibility_reader} = w.meta_data
 				return state.activeFilters.every(f =>{
-					if (features.includes(f) || supported_data.includes(f)) return true
+					if (features?.includes(f) || supported_data?.includes(f)) return true
 					if (accessibility_keyboard && f === 'Keyboard Accessible') return true
 					if (accessibility_reader && f === 'Screen Reader Accessible') return true
 


### PR DESCRIPTION
Fixes #1749.

Adds optional chaining operators to inclusion checks on widget template features and supported data in the widget catalog.