### PR TITLE
Error handling for `Notification` model's `send_email` method

### DIFF
--- a/app/core/models.py
+++ b/app/core/models.py
@@ -707,7 +707,12 @@ class Notification(models.Model):
         )
 
         # Send email, if not sent already
-        self.send_email()
+        try:
+            self.send_email()
+        except Exception:
+            logger.error(
+                "Failed to send email for user %s:", self.to_id.id, exc_info=True
+            )
 
     @classmethod
     def create_instance_notification(


### PR DESCRIPTION
Resolves #1735. Adds a simple `try/except` block around `send_email` to intercept exceptions from the email service.