### PR TITLE
Users are notified when a widget instance shared with them is undeleted.

### DIFF
--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -635,4 +635,12 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
         instance.is_deleted = False
         instance.save()
 
+        for shared_user_perm in instance.permissions.all():
+            Notification.create_instance_notification(
+                from_user=self.request.user,
+                to_user=shared_user_perm.user,
+                instance=instance,
+                mode="restored",
+            )
+
         return Response({"success": True})

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -762,6 +762,8 @@ class Notification(models.Model):
                     f"The widget is currently being used within a course in your LMS."
                 )
                 action = "access_request"
+            case "restored":
+                content = f"{user_link} restored {widget_type} widget '{widget_name}'."
             case _:
                 return None
 


### PR DESCRIPTION
Closes #1740.

Undeleting a widget instance now notifies all users with access to that instance.