### PR TITLE
CL: Fix widget engine dropdown filtering, styling of copy counter in CL detail when logged out

### DIFF
--- a/src/components/community-library-detail.jsx
+++ b/src/components/community-library-detail.jsx
@@ -235,7 +235,7 @@ const CommunityLibraryDetail = ({entry, queryError}) => {
 					<div className='card side shadow alt-border'>
 						<div className='content'>
 							<div className='row'>
-								<button className='col copy-btn' disabled={dontAllow || !entry || entry.user_copy} onClick={() => handleCopy(entry.id)}>
+								<button className={`col ${dontAllow ? "" : "copy-btn"}`} disabled={dontAllow || !entry || entry.user_copy} onClick={() => handleCopy(entry.id)}>
 									<div className='big'>{!entry ? 0 : entry.copy_count}</div>
 									<div className='row center' style={{gap:"4px"}}>
 										<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/src/components/community-library.jsx
+++ b/src/components/community-library.jsx
@@ -168,7 +168,7 @@ const CommunityLibrary = ({ widgets = [] }) => {
 	const widgetTypeOptions = useMemo(() => {
 		if (!widgets.length) return []
 		return widgets.filter((w) => (
-			w.in_catalog && w.creator !== "" && w.creator.includes("default")
+			w.in_catalog && w.creator !== "" && !w.creator.includes("default")
 		)).sort((a, b) => a.name.localeCompare(b.name))
 	}, [widgets])
 

--- a/src/components/community-library.jsx
+++ b/src/components/community-library.jsx
@@ -167,7 +167,9 @@ const CommunityLibrary = ({ widgets = [] }) => {
 
 	const widgetTypeOptions = useMemo(() => {
 		if (!widgets.length) return []
-		return widgets.filter((w) => w.in_catalog).sort((a, b) => a.name.localeCompare(b.name))
+		return widgets.filter((w) => (
+			w.in_catalog && w.creator !== "" && w.creator.includes("default")
+		)).sort((a, b) => a.name.localeCompare(b.name))
 	}, [widgets])
 
 	let contentRender = null


### PR DESCRIPTION
Fixes the Widget Engine dropdown in the Community Library currently displaying widget types that cannot be published to the library. Also fixes an issue where the copy count indicator in the detail page for a library entry shows in full opacity if the user is not an instructor.