### PR TITLE
Fixes to `myPerms` handling in collab dialog, plus better support user handling

### DIFF
--- a/src/components/my-widgets-collaborate-dialog.jsx
+++ b/src/components/my-widgets-collaborate-dialog.jsx
@@ -146,7 +146,7 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 	// does the perms set contain the current user?
 	// supportUsers always have implicit access. Otherwise, verify the user is in the perms set and isn't pending removal.
 	const containsUser = () => {
-		if (myPerms?.isSupportUser || suOverride) return true
+		if (suOverride) return true
 		for (const [id, val] of Array.from(state.updatedAllUserPerms)) {
 			if (id == currentUser.id) return !val.remove
 		}
@@ -312,6 +312,7 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 						removedCurrentUser={removedCurrentUser}
 						onChange={(userId, perms) => updatePerms(userId, perms)}
 						readOnly={myPerms?.can?.share === false && !suOverride}
+						suOverride={suOverride}
 					/>
 				)
 

--- a/src/components/my-widgets-collaborate-dialog.jsx
+++ b/src/components/my-widgets-collaborate-dialog.jsx
@@ -156,7 +156,7 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 
 		let permsObj = [];
 
-		if (delCurrUser && myPerms.accessLevel != access.FULL)
+		if (delCurrUser && myPerms?.accessLevel != access.FULL)
 		{
 			// Only send a request to update current user perms so that it doesn't get no-perm'd by the server
 			let currentUserPerms = state.updatedAllUserPerms.get(currentUser.id);
@@ -306,7 +306,7 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 						onlyOneFullPermHolder={onlyOneFullPermHolder}
 						removedCurrentUser={removedCurrentUser}
 						onChange={(userId, perms) => updatePerms(userId, perms)}
-						readOnly={myPerms?.can?.share === false}
+						readOnly={myPerms?.can?.share === false && !myPerms?.isSupportUser}
 					/>
 				)
 
@@ -364,7 +364,7 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 					<p className='disclaimer'>
 						Users with full access can edit this widget and can
 						add or remove people in this list. 
-						{onlyOneFullPermHolder && myPerms.accessLevel == access.FULL && (
+						{onlyOneFullPermHolder && myPerms?.accessLevel == access.FULL && (
 							<span>
 								<em>
 								{	'\u00A0'}Note: There must be at least one user with full access.

--- a/src/components/my-widgets-collaborate-dialog.jsx
+++ b/src/components/my-widgets-collaborate-dialog.jsx
@@ -29,6 +29,7 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 	const popperRef = useRef(null)
 	const userList = useUserList(debouncedSearchTerm)
 	const [collabUsers, setCollabUsers] = useState({})
+	const [suOverride, setSuOverride] = useState(false)
 
 	const collabUsersQueryKey = [
 		'collab-users',
@@ -72,6 +73,10 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 
 	useEffect(() => {
 		mounted.current = true
+
+		const currentUserPerms = queryClient.getQueryData(['isLoggedIn'])
+		if (currentUserPerms?.permLevel && (currentUserPerms?.permLevel == 'super_user') || currentUserPerms?.permLevel == 'support_user') setSuOverride(true)
+
 		return () => {
 			mounted.current = false
 		}
@@ -141,7 +146,7 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 	// does the perms set contain the current user?
 	// supportUsers always have implicit access. Otherwise, verify the user is in the perms set and isn't pending removal.
 	const containsUser = () => {
-		if (myPerms?.isSupportUser) return true
+		if (myPerms?.isSupportUser || suOverride) return true
 		for (const [id, val] of Array.from(state.updatedAllUserPerms)) {
 			if (id == currentUser.id) return !val.remove
 		}
@@ -236,7 +241,7 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 
 	// Can't search unless you have full access.
 	let searchContainerRender = null
-	if (myPerms?.can?.share || myPerms?.isSupportUser) {
+	if (myPerms?.can?.share || suOverride) {
 		let searchResultsRender = null
 		if (debouncedSearchTerm !== '' && state.searchText !== '' && userList.users?.length && userList.users?.length !== 0) {
 			const searchResultElements = userList.users?.map(match =>
@@ -306,13 +311,17 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 						onlyOneFullPermHolder={onlyOneFullPermHolder}
 						removedCurrentUser={removedCurrentUser}
 						onChange={(userId, perms) => updatePerms(userId, perms)}
-						readOnly={myPerms?.can?.share === false && !myPerms?.isSupportUser}
+						readOnly={myPerms?.can?.share === false && !suOverride}
 					/>
 				)
 
 				if (currentUser.id === user.id) userContentElement = rowElement
 				else mainContentElements.push(rowElement)
 			})
+
+			if (userContentElement == null && suOverride) {
+				userContentElement = <span className='not-shared'>You have implicit access to this widget due to your role as an elevated user.</span>
+			}
 
 			mainContentRender = (
 				<>

--- a/src/components/my-widgets-collaborate-dialog.scss
+++ b/src/components/my-widgets-collaborate-dialog.scss
@@ -163,7 +163,7 @@
 
 			span.not-shared {
 				display: block;
-				margin-top: 2em;
+				margin: 2em 0;
 				text-align: center;
 
 				font-size: 0.9em;

--- a/src/components/my-widgets-collaborate-user-row.jsx
+++ b/src/components/my-widgets-collaborate-user-row.jsx
@@ -148,11 +148,11 @@ const CollaborateUserRow = ({user, perms, myPerms, isCurrentUser, onlyOneFullPer
 	let optionsContent = null
 	if (!isCurrentUser) {
 		const disableRemoveOptions = (onlyOneFullPermHolder && (perms.accessLevel === access.FULL))
-		if (myPerms.accessLevel === access.FULL) {
+		if (myPerms?.accessLevel === access.FULL || myPerms?.isSupportUser) {
 			optionsContent = (
 				<>
 					<div className='options'>
-						<select disabled={readOnly || isCurrentUser || removedCurrentUser || state.contexts != null}
+						<select disabled={readOnly || isCurrentUser || removedCurrentUser || state.contexts != null || disableRemoveOptions}
 							data-testid={`${user.id}-select`}
 							tabIndex='0'
 							className='perm'

--- a/src/components/my-widgets-collaborate-user-row.jsx
+++ b/src/components/my-widgets-collaborate-user-row.jsx
@@ -41,7 +41,7 @@ const CalendarContainer = ({children}) => {
 	)
 }
 
-const CollaborateUserRow = ({user, perms, myPerms, isCurrentUser, onlyOneFullPermHolder, removedCurrentUser, onChange, readOnly}) => {
+const CollaborateUserRow = ({user, perms, myPerms, isCurrentUser, onlyOneFullPermHolder, removedCurrentUser, onChange, readOnly, suOverride}) => {
 	const [state, setState] = useState({
 		...initRowState(),
 		...perms,
@@ -87,6 +87,8 @@ const CollaborateUserRow = ({user, perms, myPerms, isCurrentUser, onlyOneFullPer
 	}
 
 	const removeContexts = () => setState({...state, contexts: null, provisionalAccessRemoved: true})
+
+	const disableRemoveOptions = (onlyOneFullPermHolder && (perms.accessLevel === access.FULL))
 
 	let selfDemoteWarningRender = null
 	if (state.showDemoteDialog) {
@@ -135,10 +137,10 @@ const CollaborateUserRow = ({user, perms, myPerms, isCurrentUser, onlyOneFullPer
 			)
 		} else {
 			expirationSettingRender = (
-				<button className={(readOnly || isCurrentUser || removedCurrentUser || perms.contexts != null) ? 'expire-open-button-disabled' : 'expire-open-button'}
+				<button className={(readOnly || isCurrentUser || removedCurrentUser || perms.contexts != null || disableRemoveOptions) ? 'expire-open-button-disabled' : 'expire-open-button'}
 					data-testid={`${user.id}-never-expire`}
 					onClick={toggleShowExpire}
-					disabled={readOnly || isCurrentUser || removedCurrentUser || perms.contexts != null}>
+					disabled={readOnly || isCurrentUser || removedCurrentUser || perms.contexts != null || disableRemoveOptions}>
 					Never
 				</button>
 			)
@@ -147,8 +149,7 @@ const CollaborateUserRow = ({user, perms, myPerms, isCurrentUser, onlyOneFullPer
 
 	let optionsContent = null
 	if (!isCurrentUser) {
-		const disableRemoveOptions = (onlyOneFullPermHolder && (perms.accessLevel === access.FULL))
-		if (myPerms?.accessLevel === access.FULL || myPerms?.isSupportUser) {
+		if (myPerms?.accessLevel === access.FULL || suOverride) {
 			optionsContent = (
 				<>
 					<div className='options'>

--- a/src/components/support-selected-instance.jsx
+++ b/src/components/support-selected-instance.jsx
@@ -269,7 +269,7 @@ const SupportSelectedInstance = ({inst, currentUser, onCopySuccess, embed = fals
 	if (showCollab) {
 		const entries = allPerms.myPerms.entries()
 		let myPerms = null
-		if (entries) myPerms = entries.next().value[1] ?? null
+		if (entries && entries.length) myPerms = entries.next().value[1] ?? null
 		// isSupportUser should always be present here, but check its value just to be sure
 		if (allPerms.myPerms && myPerms && allPerms.myPerms.isSupportUser == true) myPerms.isSupportUser = true
 		collaborateDialogRender = (

--- a/src/components/support-selected-instance.jsx
+++ b/src/components/support-selected-instance.jsx
@@ -120,8 +120,6 @@ const SupportSelectedInstance = ({inst, currentUser, onCopySuccess, embed = fals
 				}
 				othersPerms.set(perm.user, permToObj)
 			})
-			myPerms.isSupportUser = true
-
 			setAllPerms({myPerms: myPerms, otherUserPerms: othersPerms})
 		}
 	}, [perms])
@@ -270,8 +268,6 @@ const SupportSelectedInstance = ({inst, currentUser, onCopySuccess, embed = fals
 		const entries = allPerms.myPerms.entries()
 		let myPerms = null
 		if (entries && entries.length) myPerms = entries.next().value[1] ?? null
-		// isSupportUser should always be present here, but check its value just to be sure
-		if (allPerms.myPerms && myPerms && allPerms.myPerms.isSupportUser == true) myPerms.isSupportUser = true
 		collaborateDialogRender = (
 			<MyWidgetsCollaborateDialog inst={inst}
 				currentUser={currentUser}
@@ -488,7 +484,7 @@ const SupportSelectedInstance = ({inst, currentUser, onCopySuccess, embed = fals
 								name='available'
 								value={-1}
 								checked={availableDisabled}
-								onChange={() => {setAvailableDisabled(true); handleChange('open_at', -1)}}
+								onChange={() => {setAvailableDisabled(true); handleChange('open_at', null)}}
 							/>
 							<label htmlFor="now">Now</label>
 						</div>
@@ -519,7 +515,7 @@ const SupportSelectedInstance = ({inst, currentUser, onCopySuccess, embed = fals
 								id="never"
 								value={-1}
 								checked={closeDisabled}
-								onChange={() => {setCloseDisabled(true); handleChange('close_at', -1)}}
+								onChange={() => {setCloseDisabled(true); handleChange('close_at', null)}}
 							/>
 							<label htmlFor="never">Never</label>
 						</div>

--- a/src/components/support-selected-instance.jsx
+++ b/src/components/support-selected-instance.jsx
@@ -112,13 +112,13 @@ const SupportSelectedInstance = ({inst, currentUser, onCopySuccess, embed = fals
 			const myPerms = new Map()
 
 			perms.forEach(perm => {
+
+				const permToObj = rawPermsToObj(perm, isEditable)
 				
 				if (perm.user == currentUser?.id) {
-					myPerms.set(perm.user, rawPermsToObj(perm, isEditable))
+					myPerms.set(perm.user, permToObj)
 				}
-				else {
-					othersPerms.set(perm.user, rawPermsToObj(perm, isEditable))
-				}
+				othersPerms.set(perm.user, permToObj)
 			})
 			myPerms.isSupportUser = true
 
@@ -267,10 +267,15 @@ const SupportSelectedInstance = ({inst, currentUser, onCopySuccess, embed = fals
 
 	let collaborateDialogRender = null
 	if (showCollab) {
+		const entries = allPerms.myPerms.entries()
+		let myPerms = null
+		if (entries) myPerms = entries.next().value[1] ?? null
+		// isSupportUser should always be present here, but check its value just to be sure
+		if (allPerms.myPerms && myPerms && allPerms.myPerms.isSupportUser == true) myPerms.isSupportUser = true
 		collaborateDialogRender = (
 			<MyWidgetsCollaborateDialog inst={inst}
 				currentUser={currentUser}
-				myPerms={allPerms.myPerms}
+				myPerms={myPerms}
 				otherUserPerms={allPerms.otherUserPerms}
 				setOtherUserPerms={(p) => setAllPerms({...allPerms, otherUserPerms: p})}
 				onClose={() => {setShowCollab(false)}}


### PR DESCRIPTION
- `myPerms` is correctly populated when the collab dialog is launched from the support panel
- Better conditional handling of `myPerms` properties
- Better support user punch-through in collab dialog, ensuring support users can perform perms modifications regardless of their explicit access.