### PR TITLE
Fixes header style leaks in LTI css

### DIFF
--- a/src/css/lti.scss
+++ b/src/css/lti.scss
@@ -580,6 +580,7 @@ html {
 			header.header-for-students {
 				display: flex;
 				flex-direction: column;
+				align-items: center;
 
 				img {
 					width: auto;
@@ -719,6 +720,7 @@ html {
 				border-top: dotted 1px #ccc;
 
 				header {
+					display: block;
 					width: 80%;
 					margin: 1em auto;
 					text-align: center;


### PR DESCRIPTION
Resolves #1802

Arguably the header CSS additions in `include.scss` should have more specificity, but nothing else appears broken.