### PR TITLE
theme metadata property backfill

### DIFF
--- a/app/core/models.py
+++ b/app/core/models.py
@@ -1618,6 +1618,9 @@ class UserSettings(models.Model):
             self.profile_fields = updated_fields
             self.save()
 
+        elif "theme" not in self.profile_fields:
+            self.set_profile_fields("theme", "light")
+
         profile_images = SiteImage.objects.filter(
             image_type=SiteImage.ImageType.PROFILE_IMAGE
         )


### PR DESCRIPTION
We already perform backfill if the `darkMode` key is present, but not when `darkMode` is not present but the profile fields have already been initialized. This PR addresses that edge case.