### PR TITLE
Dev/11.0.2

### DIFF
--- a/app/api/permissions.py
+++ b/app/api/permissions.py
@@ -170,12 +170,17 @@ class PlayStorageInstancePermissions(permissions.BasePermission):
                 return True
 
             play_id = request.query_params.get("play_id")
-            play = LogPlay.objects.select_related("instance").filter(pk=play_id).first()
+            if play_id:
+                play = (
+                    LogPlay.objects.select_related("instance")
+                    .filter(pk=play_id)
+                    .first()
+                )
 
-            if not play.instance.playable_by_current_user(request.user):
-                return False
+                if not play or not play.instance.playable_by_current_user(request.user):
+                    return False
 
-            return True
+                return True
 
         elif request.method == "POST":
             play_id = request.data.get("play_id")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucfopen/materia",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "license": "AGPL-3.0",
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
- #1808 adds proper query param validation for `PlayStorageInstancePermissions` to prevent server errors due to missing or invalid `play_id`s.