### PR TITLE
Performance endpoint fixes and improvements

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -786,20 +786,9 @@ class ScoreSummarySerializer(serializers.Serializer):
         return sorted(results, key=lambda x: x["start_at"], reverse=True)
 
 
-# Used for incoming requests to the performance endpoint. Does NOT map to a model.
-class PerformanceRequestSerializer(serializers.Serializer):
-    most_recent = serializers.BooleanField(required=False, default=False)
-    for_semester = serializers.PrimaryKeyRelatedField(
-        queryset=DateRange.objects.all(), required=False, allow_null=True, default=None
-    )
-
-    def validate(self, data):
-        if data["most_recent"] and data["for_semester"] is not None:
-            raise serializers.ValidationError(
-                "most_recent and for_semester cannot both be provided."
-            )
-
-        return data
+# Used for validating the semester ID in the performance endpoint URL. Does NOT map to a model.
+class PerformanceSemesterSerializer(serializers.Serializer):
+    semester = serializers.PrimaryKeyRelatedField(queryset=DateRange.objects.all())
 
 
 # Used for incoming requests for qset generation. Does NOT map to a model.

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -721,6 +721,7 @@ class ScoreSummarySerializer(serializers.Serializer):
                     "id": log.semester.id,
                     "term": log.semester.semester,
                     "year": log.created_at.year,
+                    "start_at": log.semester.start_at,
                     "students": 1,
                     "count": 1,
                     "total": log.percent,
@@ -774,6 +775,7 @@ class ScoreSummarySerializer(serializers.Serializer):
                     "id": data["id"],
                     "term": data["term"],
                     "year": data["year"],
+                    "start_at": data["start_at"],
                     "students": data["students"],
                     "average": round(data["total"] / data["count"], 2),
                     "distribution": data["distribution"],
@@ -781,7 +783,7 @@ class ScoreSummarySerializer(serializers.Serializer):
                 }
             )
 
-        return sorted(results, key=lambda x: (x["year"], x["term"]), reverse=True)
+        return sorted(results, key=lambda x: x["start_at"], reverse=True)
 
 
 # Used for incoming requests for qset generation. Does NOT map to a model.

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -786,6 +786,22 @@ class ScoreSummarySerializer(serializers.Serializer):
         return sorted(results, key=lambda x: x["start_at"], reverse=True)
 
 
+# Used for incoming requests to the performance endpoint. Does NOT map to a model.
+class PerformanceRequestSerializer(serializers.Serializer):
+    most_recent = serializers.BooleanField(required=False, default=False)
+    for_semester = serializers.PrimaryKeyRelatedField(
+        queryset=DateRange.objects.all(), required=False, allow_null=True, default=None
+    )
+
+    def validate(self, data):
+        if data["most_recent"] and data["for_semester"] is not None:
+            raise serializers.ValidationError(
+                "most_recent and for_semester cannot both be provided."
+            )
+
+        return data
+
+
 # Used for incoming requests for qset generation. Does NOT map to a model.
 class QsetGenerationRequestSerializer(serializers.Serializer):
     instance = WidgetInstanceSerializer(read_only=True)

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -786,6 +786,16 @@ class ScoreSummarySerializer(serializers.Serializer):
         return sorted(results, key=lambda x: x["start_at"], reverse=True)
 
 
+class PerformanceAvailableSemesterSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DateRange
+        fields = [
+            "id",
+            "semester",
+            "year",
+        ]
+
+
 # Used for validating the semester ID in the performance endpoint URL. Does NOT map to a model.
 class PerformanceSemesterSerializer(serializers.Serializer):
     semester = serializers.PrimaryKeyRelatedField(queryset=DateRange.objects.all())

--- a/app/api/tests/test_widget_instance_views.py
+++ b/app/api/tests/test_widget_instance_views.py
@@ -1020,7 +1020,21 @@ class TestInstancePerformance(WidgetInstanceViewSetTestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, [latest_semester.id, self.semester.id])
+        self.assertEqual(
+            [dict(semester) for semester in response.data],
+            [
+                {
+                    "id": latest_semester.id,
+                    "semester": latest_semester.semester,
+                    "year": latest_semester.year,
+                },
+                {
+                    "id": self.semester.id,
+                    "semester": self.semester.semester,
+                    "year": self.semester.year,
+                },
+            ],
+        )
 
 
 class TestInstancePerms(WidgetInstanceViewSetTestCase):

--- a/app/api/tests/test_widget_instance_views.py
+++ b/app/api/tests/test_widget_instance_views.py
@@ -930,6 +930,70 @@ class TestInstancePerformance(WidgetInstanceViewSetTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsInstance(response.data, list)
 
+    def test_performance_most_recent_returns_latest_logged_semester(self):
+        latest_semester = (
+            DateRange.objects.filter(year=2025).order_by("start_at").first()
+        )
+        LogPlay.objects.create(
+            id=str(uuid.uuid4()),
+            instance=self.author_instance,
+            user=self.regular_user,
+            is_valid=False,
+            is_complete=True,
+            score=90,
+            score_possible=100,
+            percent=90.0,
+            elapsed=300,
+            qset=self.author_qset,
+            ip="127.0.0.1",
+            auth="",
+            referrer_url="",
+            context_id="",
+            semester=latest_semester,
+        )
+
+        self.client.force_authenticate(user=self.regular_user)
+        response = self.client.get(
+            f"/api/instances/{self.author_instance.id}/performance/",
+            {"most_recent": "true"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"][0]["id"], latest_semester.id)
+        self.assertEqual(response.data["preceding_semester_id"], self.semester.id)
+
+    def test_performance_for_semester_returns_requested_semester(self):
+        latest_semester = (
+            DateRange.objects.filter(year=2025).order_by("start_at").first()
+        )
+        LogPlay.objects.create(
+            id=str(uuid.uuid4()),
+            instance=self.author_instance,
+            user=self.regular_user,
+            is_valid=False,
+            is_complete=True,
+            score=90,
+            score_possible=100,
+            percent=90.0,
+            elapsed=300,
+            qset=self.author_qset,
+            ip="127.0.0.1",
+            auth="",
+            referrer_url="",
+            context_id="",
+            semester=latest_semester,
+        )
+
+        self.client.force_authenticate(user=self.regular_user)
+        response = self.client.get(
+            f"/api/instances/{self.author_instance.id}/performance/",
+            {"for_semester": self.semester.id},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"][0]["id"], self.semester.id)
+        self.assertIsNone(response.data["preceding_semester_id"])
+
 
 class TestInstancePerms(WidgetInstanceViewSetTestCase):
     """Tests for GET/PUT /api/instances/{id}/perms/"""

--- a/app/api/tests/test_widget_instance_views.py
+++ b/app/api/tests/test_widget_instance_views.py
@@ -930,7 +930,7 @@ class TestInstancePerformance(WidgetInstanceViewSetTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsInstance(response.data, list)
 
-    def test_performance_most_recent_returns_latest_logged_semester(self):
+    def test_performance_latest_returns_latest_logged_semester(self):
         latest_semester = (
             DateRange.objects.filter(year=2025).order_by("start_at").first()
         )
@@ -954,15 +954,14 @@ class TestInstancePerformance(WidgetInstanceViewSetTestCase):
 
         self.client.force_authenticate(user=self.regular_user)
         response = self.client.get(
-            f"/api/instances/{self.author_instance.id}/performance/",
-            {"most_recent": "true"},
+            f"/api/instances/{self.author_instance.id}/performance/latest/",
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["results"][0]["id"], latest_semester.id)
         self.assertEqual(response.data["preceding_semester_id"], self.semester.id)
 
-    def test_performance_for_semester_returns_requested_semester(self):
+    def test_performance_semester_returns_requested_semester(self):
         latest_semester = (
             DateRange.objects.filter(year=2025).order_by("start_at").first()
         )
@@ -986,13 +985,42 @@ class TestInstancePerformance(WidgetInstanceViewSetTestCase):
 
         self.client.force_authenticate(user=self.regular_user)
         response = self.client.get(
-            f"/api/instances/{self.author_instance.id}/performance/",
-            {"for_semester": self.semester.id},
+            f"/api/instances/{self.author_instance.id}/performance/semester/{self.semester.id}/",
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["results"][0]["id"], self.semester.id)
         self.assertIsNone(response.data["preceding_semester_id"])
+
+    def test_performance_activity_returns_semester_ids_with_logs(self):
+        latest_semester = (
+            DateRange.objects.filter(year=2025).order_by("start_at").first()
+        )
+        LogPlay.objects.create(
+            id=str(uuid.uuid4()),
+            instance=self.author_instance,
+            user=self.regular_user,
+            is_valid=False,
+            is_complete=True,
+            score=90,
+            score_possible=100,
+            percent=90.0,
+            elapsed=300,
+            qset=self.author_qset,
+            ip="127.0.0.1",
+            auth="",
+            referrer_url="",
+            context_id="",
+            semester=latest_semester,
+        )
+
+        self.client.force_authenticate(user=self.regular_user)
+        response = self.client.get(
+            f"/api/instances/{self.author_instance.id}/performance/activity/"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [latest_semester.id, self.semester.id])
 
 
 class TestInstancePerms(WidgetInstanceViewSetTestCase):

--- a/app/api/tests/test_widget_instance_views.py
+++ b/app/api/tests/test_widget_instance_views.py
@@ -992,7 +992,7 @@ class TestInstancePerformance(WidgetInstanceViewSetTestCase):
         self.assertEqual(response.data["results"][0]["id"], self.semester.id)
         self.assertIsNone(response.data["preceding_semester_id"])
 
-    def test_performance_activity_returns_semester_ids_with_logs(self):
+    def test_performance_available_returns_semester_ids_with_logs(self):
         latest_semester = (
             DateRange.objects.filter(year=2025).order_by("start_at").first()
         )
@@ -1016,7 +1016,7 @@ class TestInstancePerformance(WidgetInstanceViewSetTestCase):
 
         self.client.force_authenticate(user=self.regular_user)
         response = self.client.get(
-            f"/api/instances/{self.author_instance.id}/performance/activity/"
+            f"/api/instances/{self.author_instance.id}/performance/available/"
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -85,7 +85,7 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
         seen = set()
 
         for tag_name in tag_names:
-            cleaned = " ".join((tag_name or "").strip().replace("#","").split())
+            cleaned = " ".join((tag_name or "").strip().replace("#", "").split())
             canonical = Tag.normalize_name(cleaned)
             if not canonical or canonical in seen:
                 continue
@@ -394,15 +394,16 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
 
         logs = LogPlay.objects.filter(instance=instance)
 
-        # only prefetch storage logs if storage is enabled to reduce unnecessary DB pressure
         if instance.widget.is_storage_enabled:
             logs = (
-                logs.order_by("-created_at", "semester")
+                logs.order_by("-semester__start_at", "-created_at")
                 .select_related("semester")
                 .prefetch_related("storage_logs")
             )
         else:
-            logs = logs.order_by("-created_at", "semester").select_related("semester")
+            logs = logs.order_by("-semester__start_at", "-created_at").select_related(
+                "semester"
+            )
 
         summary = ScoreSummarySerializer.create_from_plays(
             logs, include_storage=instance.widget.is_storage_enabled

--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -14,6 +14,7 @@ from api.permissions import (
 from api.serializers import (
     LibraryEntrySerializer,
     ObjectPermissionSerializer,
+    PerformanceAvailableSemesterSerializer,
     PerformanceSemesterSerializer,
     PermsUpdateRequestListSerializer,
     PlayIdSerializer,
@@ -469,7 +470,12 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=["get"], url_path="performance/available")
     def performance_available(self, request, pk=None):
         instance = self.get_object()
-        return Response(SemesterService.get_semester_ids_with_logs(instance))
+        semesters = SemesterService.get_semester_ids_with_logs(instance)
+
+        serializer = PerformanceAvailableSemesterSerializer(semesters, many=True)
+        return Response(serializer.data)
+
+        # return Response(SemesterService.get_semester_ids_with_logs(instance))
 
     # retrieves performance data for a given widget instance for the latest semester available
     @action(detail=True, methods=["get"], url_path="performance/latest")

--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -14,6 +14,7 @@ from api.permissions import (
 from api.serializers import (
     LibraryEntrySerializer,
     ObjectPermissionSerializer,
+    PerformanceRequestSerializer,
     PermsUpdateRequestListSerializer,
     PlayIdSerializer,
     PublishToLibrarySerializer,
@@ -31,6 +32,7 @@ from community_library.models import (
 )
 from core.message_exception import MsgFailure, MsgInvalidInput, MsgNoPerm
 from core.models import (
+    DateRange,
     LogActivity,
     LogPlay,
     Notification,
@@ -42,6 +44,7 @@ from core.models import (
 from core.services.instance_service import WidgetInstanceService
 from core.services.perm_service import PermService
 from core.services.play_data_exporter_service import PlayDataExporterService
+from core.services.semester_service import SemesterService
 from django.db import transaction
 from django.db.models import F
 from django.http import HttpResponse
@@ -392,7 +395,26 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
     def performance(self, request, pk=None):
         instance = self.get_object()
 
-        logs = LogPlay.objects.filter(instance=instance)
+        params = PerformanceRequestSerializer(data=request.query_params)
+        params.is_valid(raise_exception=True)
+
+        semester = None
+
+        if params.validated_data["most_recent"]:
+            semester = SemesterService.find_nearest_semester_with_logs(
+                instance, DateRange.objects.order_by("-start_at")
+            )
+        elif params.validated_data["for_semester"] is not None:
+            semester = params.validated_data["for_semester"]
+
+        filters = {
+            "instance": instance,
+        }
+
+        if semester is not None:
+            filters["semester"] = semester
+
+        logs = LogPlay.objects.filter(**filters)
 
         if instance.widget.is_storage_enabled:
             logs = (
@@ -411,7 +433,28 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
 
         serialized = ScoreSummarySerializer(data=summary, many=True)
         serialized.is_valid(raise_exception=True)
-        return Response(serialized.data)
+
+        # return a flat list of semesters if no semester-specific query param is provided
+        if semester is None:
+            return Response(serialized.data)
+
+        # calculate the most recent preceding semester (if any) with existing play logs, so the
+        # client knows which semester ID to request next
+        preceding_semester = SemesterService.find_nearest_semester_with_logs(
+            instance,
+            DateRange.objects.filter(start_at__lt=semester.start_at).order_by(
+                "-start_at"
+            ),
+        )
+
+        return Response(
+            {
+                "results": serialized.data,
+                "preceding_semester_id": (
+                    preceding_semester.id if preceding_semester is not None else None
+                ),
+            }
+        )
 
     @action(
         detail=True,

--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -14,7 +14,7 @@ from api.permissions import (
 from api.serializers import (
     LibraryEntrySerializer,
     ObjectPermissionSerializer,
-    PerformanceRequestSerializer,
+    PerformanceSemesterSerializer,
     PermsUpdateRequestListSerializer,
     PlayIdSerializer,
     PublishToLibrarySerializer,
@@ -77,7 +77,11 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
 
     # queryset filtering managed via UserInstanceFilterBackend
     def get_queryset(self):
-        if self.action == "performance":
+        if self.action in (
+            "performance",
+            "performance_latest",
+            "performance_semester",
+        ):
             return WidgetInstance.objects.select_related("widget")
         else:
             return WidgetInstance.objects.all()
@@ -157,7 +161,12 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
         # score distribution needs to be accessible to anyone who can play an instance
         # this either requires authentication (for normal instances)
         # or public visibility (for guest instances)
-        elif self.action == "performance":
+        elif self.action in (
+            "performance",
+            "performance_available",
+            "performance_latest",
+            "performance_semester",
+        ):
             permission_classes = [IsAuthenticated | InstanceHasGuestAccess]
 
         # must have (any) access to instance or elevated perms
@@ -391,22 +400,7 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
             {"lock_obtained": WidgetInstanceService.get_lock(instance.id, request.user)}
         )
 
-    @action(detail=True, methods=["get"])
-    def performance(self, request, pk=None):
-        instance = self.get_object()
-
-        params = PerformanceRequestSerializer(data=request.query_params)
-        params.is_valid(raise_exception=True)
-
-        semester = None
-
-        if params.validated_data["most_recent"]:
-            semester = SemesterService.find_nearest_semester_with_logs(
-                instance, DateRange.objects.order_by("-start_at")
-            )
-        elif params.validated_data["for_semester"] is not None:
-            semester = params.validated_data["for_semester"]
-
+    def _summarize_performance(self, instance, semester=None):
         filters = {
             "instance": instance,
         }
@@ -434,26 +428,72 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
         serialized = ScoreSummarySerializer(data=summary, many=True)
         serialized.is_valid(raise_exception=True)
 
-        # return a flat list of semesters if no semester-specific query param is provided
-        if semester is None:
-            return Response(serialized.data)
+        return serialized.data
+
+    def _performance_for_semester_response(self, instance, semester):
+        results = (
+            self._summarize_performance(instance, semester)
+            if semester is not None
+            else []
+        )
 
         # calculate the most recent preceding semester (if any) with existing play logs, so the
         # client knows which semester ID to request next
-        preceding_semester = SemesterService.find_nearest_semester_with_logs(
-            instance,
-            DateRange.objects.filter(start_at__lt=semester.start_at).order_by(
-                "-start_at"
-            ),
+        preceding_semester = (
+            SemesterService.find_nearest_semester_with_logs(
+                instance,
+                DateRange.objects.filter(start_at__lt=semester.start_at).order_by(
+                    "-start_at"
+                ),
+            )
+            if semester is not None
+            else None
         )
 
         return Response(
             {
-                "results": serialized.data,
+                "results": results,
                 "preceding_semester_id": (
                     preceding_semester.id if preceding_semester is not None else None
                 ),
             }
+        )
+
+    # retrieves a flat list of performance data for a given widget instance
+    @action(detail=True, methods=["get"])
+    def performance(self, request, pk=None):
+        instance = self.get_object()
+        return Response(self._summarize_performance(instance))
+
+    # retrieves a flat list of semester IDs that contain play logs for a given widget instance
+    @action(detail=True, methods=["get"], url_path="performance/available")
+    def performance_available(self, request, pk=None):
+        instance = self.get_object()
+        return Response(SemesterService.get_semester_ids_with_logs(instance))
+
+    # retrieves performance data for a given widget instance for the latest semester available
+    @action(detail=True, methods=["get"], url_path="performance/latest")
+    def performance_latest(self, request, pk=None):
+        instance = self.get_object()
+        semester = SemesterService.find_nearest_semester_with_logs(
+            instance, DateRange.objects.order_by("-start_at")
+        )
+        return self._performance_for_semester_response(instance, semester)
+
+    # retrieves performance data for a given widget instance and a given semester
+    @action(
+        detail=True,
+        methods=["get"],
+        url_path="performance/semester/(?P<semester_id>[^/.]+)",
+    )
+    def performance_semester(self, request, pk=None, semester_id=None):
+        instance = self.get_object()
+
+        params = PerformanceSemesterSerializer(data={"semester": semester_id})
+        params.is_valid(raise_exception=True)
+
+        return self._performance_for_semester_response(
+            instance, params.validated_data["semester"]
         )
 
     @action(

--- a/app/core/services/semester_service.py
+++ b/app/core/services/semester_service.py
@@ -1,4 +1,4 @@
-from core.models import DateRange
+from core.models import DateRange, LogPlay
 from django.core.cache import cache
 from django.utils import timezone
 
@@ -24,3 +24,30 @@ class SemesterService:
         # Cache it and return
         cache.set("current-semester", cur_semester, 86400)  # cache for 24hrs
         return cur_semester
+
+    def get_semester_by_id(id) -> DateRange:
+
+        cached_result = cache.get(f"semester-{id}")
+        if cached_result is not None:
+            return cached_result
+
+        semester = DateRange.objects.filter(pk=id).first()
+
+        if semester is not None:
+            cache.set(f"semester-{id}", semester, 86400)
+
+        return semester
+
+    @staticmethod
+    def find_nearest_semester_with_logs(
+        instance, ordered_semesters
+    ) -> DateRange | None:
+        # semesters are few, so checking them in the given order and stopping at the first
+        # indexed exists() hit avoids scanning the much larger log_play table
+        for candidate in ordered_semesters:
+            if LogPlay.objects.filter(
+                instance=instance, semester_id=candidate.id
+            ).exists():
+                return candidate
+
+        return None

--- a/app/core/services/semester_service.py
+++ b/app/core/services/semester_service.py
@@ -25,6 +25,7 @@ class SemesterService:
         cache.set("current-semester", cur_semester, 86400)  # cache for 24hrs
         return cur_semester
 
+    @staticmethod
     def get_semester_by_id(id) -> DateRange:
 
         cached_result = cache.get(f"semester-{id}")

--- a/app/core/services/semester_service.py
+++ b/app/core/services/semester_service.py
@@ -63,7 +63,5 @@ class SemesterService:
         )
 
         return list(
-            DateRange.objects.filter(id__in=list(semester_ids))
-            .order_by("-start_at")
-            .values_list("id", flat=True)
+            DateRange.objects.filter(id__in=list(semester_ids)).order_by("-start_at")
         )

--- a/app/core/services/semester_service.py
+++ b/app/core/services/semester_service.py
@@ -39,12 +39,11 @@ class SemesterService:
 
         return semester
 
+    # performance-sensitive method to locate the nearest (chronologically) semester that contains play logs
     @staticmethod
     def find_nearest_semester_with_logs(
         instance, ordered_semesters
     ) -> DateRange | None:
-        # semesters are few, so checking them in the given order and stopping at the first
-        # indexed exists() hit avoids scanning the much larger log_play table
         for candidate in ordered_semesters:
             if LogPlay.objects.filter(
                 instance=instance, semester_id=candidate.id
@@ -52,3 +51,19 @@ class SemesterService:
                 return candidate
 
         return None
+
+    # performance-sensitive method to identify all semesters that contain play logs for a give instance
+    @staticmethod
+    def get_semester_ids_with_logs(instance) -> list[int]:
+        semester_ids = (
+            LogPlay.objects.filter(instance=instance)
+            .order_by()
+            .values_list("semester_id", flat=True)
+            .distinct()
+        )
+
+        return list(
+            DateRange.objects.filter(id__in=list(semester_ids))
+            .order_by("-start_at")
+            .values_list("id", flat=True)
+        )

--- a/src/components/my-widgets-export.jsx
+++ b/src/components/my-widgets-export.jsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { apiGetSemestersAvailable } from '../util/api'
 import Modal from './modal'
+import LoadingIcon from './loading-icon'
 import './my-widgets-export.scss'
-import {useMutation} from "@tanstack/react-query";
+import {useMutation} from "@tanstack/react-query"
 
 const DEFAULT_OPTIONS = ['Questions and Answers']
 
@@ -14,21 +17,26 @@ const initState = () => ({
 	semesterOptions: []
 })
 
-const MyWidgetsExport = ({onClose, inst, scores}) => {
+const MyWidgetsExport = ({onClose, inst}) => {
 	const [state, setState] = useState(initState())
 	const [error, setError] = useState(null)
 	const [showOptions, setShowOptions] = useState(false)
 
+	const { data: semestersAvailable, isFetched, error: fetchError } = useQuery({
+		queryKey: ['semesters-available', inst.id],
+		queryFn: () => apiGetSemestersAvailable(inst.id),
+		enabled: !!inst && !!inst.id,
+		staleTime: Infinity,
+		placeholderData: [],
+		retry: false
+	})
+
 	// Initializes data
 	useEffect (() => {
-		let hasScores = false
+		let hasScores = semestersAvailable && semestersAvailable.length
 		let tmpOps = DEFAULT_OPTIONS
 
-		scores.forEach((val) => {
-			if (val.distribution) hasScores = true
-		})
-
-		if (scores.length === 0 || !hasScores) {
+		if (!hasScores) {
 			setState({...state, exportOptions: DEFAULT_OPTIONS, exportType: tmpOps[0], header: 'Export Options Limited, No Scores Available'})
 		}
 		else {
@@ -39,11 +47,11 @@ const MyWidgetsExport = ({onClose, inst, scores}) => {
 				tmpOps = tmpOps.concat(inst.widget.meta_data.playdata_exporters)
 			}
 
-			let options = new Array(scores.length).fill(false)
+			let options = new Array(semestersAvailable.length).fill(false)
 			options[0] = true
 			setState({...state, exportOptions: tmpOps, exportType: tmpOps[0], semesterOptions: options})
 		}
-	}, [])
+	}, [semestersAvailable])
 
 	// Sets selected semesters and their respective header text
 	useEffect(() => {
@@ -59,8 +67,8 @@ const MyWidgetsExport = ({onClose, inst, scores}) => {
 						str_cpy += ','
 					}
 
-					str += scores[i].year + ' ' + scores[i].term
-					str_cpy += scores[i].year + '-' + scores[i].term
+					str += semestersAvailable[i].year + ' ' + semestersAvailable[i].semester
+					str_cpy += semestersAvailable[i].year + '-' + semestersAvailable[i].semester
 				}
 			}
 
@@ -79,7 +87,7 @@ const MyWidgetsExport = ({onClose, inst, scores}) => {
 
 	const checkAllVals = () => {
 		if (state.semesterOptions.length > 0) {
-			const arr = new Array(scores.length).fill(!state.checkAll)
+			const arr = new Array(semestersAvailable.length).fill(!state.checkAll)
 			setState({...state, semesterOptions: arr, checkAll: !state.checkAll})
 		}
 	}
@@ -162,22 +170,26 @@ const MyWidgetsExport = ({onClose, inst, scores}) => {
 		exportDataDownloader.mutate()
 	}
 
-	const semesterOptionElements = scores.map((val, index) => (
-		<li key={index}>
-			<label className='checkbox-wrapper' htmlFor={val.id}>
-				<input type='checkbox'
-					id={val.id}
-					className='semester'
-					name={val.id}
-					disabled={scores.length === 1}
-					checked={state.semesterOptions[index] || false} // makes sure it will never be null
-					onChange={() => {semesterCheck(index)}}></input>
-				<span className='custom-checkbox'></span>
-				{val.year + ' ' + val.term}
-			</label>
+	let semesterOptionElements = <LoadingIcon />
 
-		</li>
-	))
+	if (isFetched) {
+		semesterOptionElements = semestersAvailable.map((val, index) => (
+			<li key={index}>
+				<label className='checkbox-wrapper' htmlFor={val.id}>
+					<input type='checkbox'
+						id={val.id}
+						className='semester'
+						name={val.id}
+						disabled={semestersAvailable.length === 1}
+						checked={state.semesterOptions[index] || false} // makes sure it will never be null
+						onChange={() => {semesterCheck(index)}}></input>
+					<span className='custom-checkbox'></span>
+					{val.year + ' ' + val.semester}
+				</label>
+
+			</li>
+		))
+	}
 
 	return (
 		<Modal onClose={onClose} noGutter>
@@ -228,11 +240,11 @@ const MyWidgetsExport = ({onClose, inst, scores}) => {
 			<div className={`download-options ${ showOptions ? 'active' : ''}`}>
 				<h4>Semesters</h4>
 				<p className='export_which'>Export which semesters?</p>
-				<p className={`export-none ${scores.length === 0 ? 'active' : ''}`}>
+				<p className={`export-none ${semestersAvailable.length === 0 ? 'active' : ''}`}>
 					No semesters available
 				</p>
 				<ul>
-					<li className={`${scores.length > 1 ? 'active' : ''}`}>
+					<li className={`${semestersAvailable.length > 1 ? 'active' : ''}`}>
 						<label className='checkbox-wrapper' htmlFor='checkall'>
 							<input type='checkbox'
 								id='checkall'

--- a/src/components/my-widgets-export.scss
+++ b/src/components/my-widgets-export.scss
@@ -203,6 +203,12 @@
 		margin: 1.375em 0 0 0;
 	}
 
+	.icon-holder .loading-icon {
+		background: #fff;
+		border: solid 30px #fff;
+		border-radius: 15px;
+	}
+
 	li {
 		margin-bottom: 10px;
 
@@ -252,5 +258,11 @@
 		&:first-of-type {
 			border-bottom: 1px #d6d6d6 solid;
 		}
+	}
+
+	.icon-holder .loading-icon {
+		background: #1d1f25;
+		border: solid 30px #1d1f25;
+		border-radius: 15px;
 	}
 }

--- a/src/components/my-widgets-score-semester-storage.jsx
+++ b/src/components/my-widgets-score-semester-storage.jsx
@@ -31,8 +31,8 @@ const MyWidgetScoreSemesterStorage = ({semester, instId, setInvalidLogin}) => {
 	const mounted = useRef(false)
 	const [error, setError] = useState('')
 	const { data: results, error: scoreStorageError } = useQuery({
-		queryKey: ['score-storage', instId],
-		queryFn: () => apiGetStorageData(instId),
+		queryKey: ['score-storage', instId, semester.year, semester.term],
+		queryFn: () => apiGetStorageData(instId, semester.year, semester.term),
 		enabled: !!instId,
 		staleTime: Infinity,
 		placeholderData: {},

--- a/src/components/my-widgets-scores.jsx
+++ b/src/components/my-widgets-scores.jsx
@@ -146,7 +146,6 @@ const MyWidgetsScores = ({inst, contexts, beardMode, setInvalidLogin}) => {
 		exportRender = (
 			<MyWidgetsExport onClose={closeExport}
 				inst={inst}
-				scores={currScores}
 			/>
 		)
 	}

--- a/src/components/my-widgets-scores.jsx
+++ b/src/components/my-widgets-scores.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react'
+import React, { useState, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { apiGetScoreSummary } from '../util/api'
 import MyWidgetScoreSemester from './my-widgets-score-semester'
@@ -8,19 +8,36 @@ import NoScoreContent from './no-score-content'
 import './my-widgets-scores.scss'
 
 const MyWidgetsScores = ({inst, contexts, beardMode, setInvalidLogin}) => {
+
+	const visibilityAnchor = useRef(null)
+	const shouldScroll = useRef(false)
+
 	const [state, setState] = useState({
-		isShowingAll: false,
+		loadedSemesters: [],
+		nextSemesterToLoad: -1,
 		hasScores: false,
 		showExport: false
 	})
 	const [error, setError] = useState('')
-	const { data: currScores, isFetched, error: currScoresError } = useQuery({
-		queryKey: ['score-summary', inst.id],
-		queryFn: () => apiGetScoreSummary(inst.id),
-		enabled: !!inst && !!inst.id,
+
+	// memoize lastLoadedSemester for use as a query key
+	const lastLoadedSemester = useMemo(() => {
+
+		if (!state.loadedSemesters || !state.loadedSemesters.length) return -1
+		else return state.loadedSemesters[state.loadedSemesters.length -1].id
+
+	}, [state.loadedSemesters])
+
+	const { data: currScores, isFetching, error: currScoresError, refetch: getMoreScoreSummaries } = useQuery({
+		queryKey: ['score-summary', inst.id, lastLoadedSemester],
+		queryFn: () => {
+			if (state.nextSemesterToLoad == -1) return apiGetScoreSummary(inst.id, true)
+			else return apiGetScoreSummary(inst.id, false, state.nextSemesterToLoad)
+		},
+		enabled: !!inst && !!inst.id && lastLoadedSemester == -1,
 		staleTime: Infinity,
 		placeholderData: [],
-		retry: false
+		retry: false,
 	})
 
 	useEffect(() => {
@@ -34,26 +51,41 @@ const MyWidgetsScores = ({inst, contexts, beardMode, setInvalidLogin}) => {
 		}
 	}, [currScoresError])
 
-	// Initializes the data when widget changes
+	// reset loaded semester data when the selected instance changes
+	useEffect(() => {
+		setState(state => ({...state, loadedSemesters: [], nextSemesterToLoad: -1, hasScores: false, showExport: false}))
+		shouldScroll.current = false
+	},[inst.id])
+
+	// update score display when new semester data is loaded
 	useEffect(() => {
 		let hasScores = false
-		if (currScores) {
-			currScores.map(val => {
-				if (val.distribution) hasScores = true
+		const prevLoadedSemesterIds = state.loadedSemesters.map(term => term.id)
+		const prevLoadedSemesters = [ ...state.loadedSemesters ]
+
+		if (currScores && currScores.length > 0) {
+			currScores.forEach(semester => {
+				if (semester.distribution) hasScores = true
+				if (!prevLoadedSemesterIds.includes(semester.id)) prevLoadedSemesters.push(semester)
 			})
 
 			setState({
 				hasScores: hasScores,
-				showExport: false
+				showExport: false,
+				loadedSemesters: [...prevLoadedSemesters],
+				nextSemesterToLoad: currScores[currScores.length - 1].preceding_semester_id
 			})
 		}
+
 	}, [JSON.stringify(currScores)])
 
-	const displayedSemesters = useMemo(() => {
-		if (currScores && (state.isShowingAll || currScores.length < 2)) return currScores // all semester being displayed
-		else if (currScores) return currScores.slice(0,1) // show just one semester, gracefully handles empty array
-		else return [] // no scores yet
-	}, [currScores, state.isShowingAll])
+	// enable scrolling to new semester element when appropriate
+	useEffect(() => {
+		if (state.loadedSemesters.length > 1 && shouldScroll.current) {
+			visibilityAnchor.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+			shouldScroll.current = false
+		}
+	}, [state.loadedSemesters])
 
 	const openExport = () => {
 		if (!inst.is_draft) setState({...state, showExport: true})
@@ -64,7 +96,7 @@ const MyWidgetsScores = ({inst, contexts, beardMode, setInvalidLogin}) => {
 
 	const containsStorage = () => {
 		let hasStorageData = false
-		for(const semester of displayedSemesters) {
+		for(const semester of state.loadedSemesters) {
 			if (semester.storage) {
 				hasStorageData = true
 			}
@@ -73,16 +105,21 @@ const MyWidgetsScores = ({inst, contexts, beardMode, setInvalidLogin}) => {
 		return hasStorageData
 	}
 
-	const handleShowOlderClick = () => setState({...state, isShowingAll: !state.isShowingAll})
+	const handleShowOlderClick = () => {
+		getMoreScoreSummaries()
+		if (state.nextSemesterToLoad != -1) shouldScroll.current = true
+	}
+
+	console.log(shouldScroll.current)
 
 	let contentRender = <LoadingIcon />
 	if (error) {
 		contentRender = <div className='error'>{error}</div>
 	}
-	else if (isFetched) {
+	else if (!isFetching) {
 		contentRender = <NoScoreContent scorable={inst.widget.is_scorable} isDraft={inst.is_draft} beardMode={beardMode} />
 		if (state.hasScores || containsStorage()) {
-			const semesterElements = displayedSemesters.map(semester => (
+			const semesterElements = state.loadedSemesters.map(semester => (
 				<MyWidgetScoreSemester key={semester.id}
 					semester={semester}
 					instId={inst.id}
@@ -96,10 +133,11 @@ const MyWidgetsScores = ({inst, contexts, beardMode, setInvalidLogin}) => {
 				<div>
 					{ semesterElements }
 					<a role='button'
-						className={`show-older-scores-button ${currScores?.length > 1 ? '' : 'hide'}`}
+						className={`show-older-scores-button ${state.nextSemesterToLoad != -1  ? '' : 'hide'}`}
 						onClick={handleShowOlderClick}>
-						{ state.isShowingAll ? 'Hide' : 'Show' } older scores...
+						{ state.nextSemesterToLoad == -1 ? 'Hide' : 'Show' } older scores...
 					</a>
+					<div id='visibility-anchor' ref={visibilityAnchor}></div>
 				</div>
 			)
 		}

--- a/src/components/my-widgets-scores.jsx
+++ b/src/components/my-widgets-scores.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
+import React, { useState, useEffect, useMemo, useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { apiGetScoreSummary } from '../util/api'
 import MyWidgetScoreSemester from './my-widgets-score-semester'

--- a/src/components/my-widgets-scores.jsx
+++ b/src/components/my-widgets-scores.jsx
@@ -110,8 +110,6 @@ const MyWidgetsScores = ({inst, contexts, beardMode, setInvalidLogin}) => {
 		if (state.nextSemesterToLoad != -1) shouldScroll.current = true
 	}
 
-	console.log(shouldScroll.current)
-
 	let contentRender = <LoadingIcon />
 	if (error) {
 		contentRender = <div className='error'>{error}</div>

--- a/src/components/my-widgets-scores.scss
+++ b/src/components/my-widgets-scores.scss
@@ -567,6 +567,10 @@
 		}
 	}
 
+	#visibility-anchor {
+		height: 1px;
+	}
+
 	.dataTables_info_holder {
 		display: flex;
 		align-items: center;

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -441,6 +441,15 @@ export const apiGetScoreSummary = (instId, mostRecent = false, semesterId = -1) 
 }
 
 /**
+ * Takes a widget instance ID, and returns a list of semesters that contain play data.
+ * @param {string} instId - The ID of the widget instance.
+ * @returns {Promise<any>} - Parsed response data.
+ */
+export const apiGetSemestersAvailable = (instId) => {
+	return handleRequest(methods.GET, `/api/instances/${instId}/performance/available/`)
+}
+
+/**
  * Takes a widget instance ID, and returns a summary of scores submitted for that instance separated by semester.
  * @param {string} instId - The ID of the widget instance.
  * @param {string} term - The time of year, typically 'spring', 'summer' or 'fall'.

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -501,8 +501,11 @@ export const apiGetPlayLogs = (instId, term, year, contexts, page_number) => {
 		})
 }
 
-export const apiGetStorageData = instId => {
-	return handleRequest(methods.GET, `/api/storage/?inst_id=${instId}`);
+export const apiGetStorageData = (instId, year = null, term = null) => {
+	const params = new URLSearchParams({ inst_id: instId })
+	if (year !== null) params.set('year', year)
+	if (term !== null) params.set('term', term)
+	return handleRequest(methods.GET, `/api/storage/?${params}`);
 }
 
 /**

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -400,10 +400,24 @@ export const apiGetWidgetInstancePreviewScores = (playId, previewInstId, snapsho
  * @param {string} instId - The ID of the widget instance.
  * @returns {Promise<any>} - Parsed response data.
  */
-export const apiGetScoreSummary = instId => {
-	return handleRequest(methods.GET, `/api/instances/${instId}/performance/`)
+export const apiGetScoreSummary = (instId, mostRecent = false, semesterId = -1) => {
+
+	let url = `/api/instances/${instId}/performance/`
+
+	if (mostRecent) url += '?most_recent=true'
+	else if (semesterId != -1) url += `?for_semester=${semesterId}`
+
+	return handleRequest(methods.GET, url)
 	.then(data => {
-		const scores = data
+
+		if (Array.isArray(data) && !data.length) return []
+
+		let scores = data
+
+		if (mostRecent || semesterId != -1) {
+			scores = data.results
+		}
+
 		const ranges = [
 			'0-9',
 			'10-19',
@@ -416,9 +430,10 @@ export const apiGetScoreSummary = instId => {
 			'80-89',
 			'90-100',
 		]
-		scores.forEach(semester => {
+		scores.forEach((semester, index) => {
 			semester.graphData = semester.distribution?.length ? semester.distribution?.map((d, i) => ({ label: ranges[i], value: d })) : null
 			semester.totalScores = semester.distribution?.length ? semester.distribution?.reduce((total, count) => total + count) : 0
+			semester.preceding_semester_id = data.preceding_semester_id ?? (scores[index - 1] != undefined ? scores[index - 1].id : -1)
 		})
 
 		return scores

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -404,8 +404,8 @@ export const apiGetScoreSummary = (instId, mostRecent = false, semesterId = -1) 
 
 	let url = `/api/instances/${instId}/performance/`
 
-	if (mostRecent) url += '?most_recent=true'
-	else if (semesterId != -1) url += `?for_semester=${semesterId}`
+	if (mostRecent) url += 'latest/'
+	else if (semesterId != -1) url += `semester/${semesterId}/`
 
 	return handleRequest(methods.GET, url)
 	.then(data => {


### PR DESCRIPTION
Resolves #1820 

- Fixes semester sorting in the score summary serializer.
- Major updates and additions to the `/api/instances/pk/performance/` endpoint:
    - The existing `/api/instances/<instance pk>/performance/` endpoint remains consistent with earlier behavior.
    - Adds `/api/instances/<instance pk>/performance/latest/` to retrieve performance data for the latest semester that contains play logs.
    - Adds `/api/instances/<instance pk>/performance/semester/<semester pk>/` to retrieve performance data for a given semester ID.
    - Adds `/api/instances/<instance pk>/performance/available/` to return a flat list of semesters that contain play logs.
- Updates the `MyWidgetsScores` component and `apiGetScoreSummary` method to request individual semester performance data:
    - The first request to `/performance/` uses `/latest/` to retrieve the most recent semester's data. Subsequent requests use `/semester/<semester pk>/` to request subsequent data per-semester.
    - Performance requests using `/latest/` or `/semester/<semester pk>/` return a `preceding_semester_id` value that can be used to request subsequent semester data.
    - Updated the score summary query to progressively request each semester individually. Individual semesters are uniquely keyed to the query cache to ensure previously loaded semesters are not refetched if the selected widget changes and is then re-selected.
    - Added a scroll behavior to the 'Show Older Scores...` button below the last requested semester.
- Storage data retrieval now properly filters by `year` and `term` in addition to instance ID per score semester.
- Updated the export dialog to use the new `/performance/available/` endpoint to populate the list of semesters with data available.
- Updated the `widget_instance` API test suite to cover the new endpoints.
