### PR TITLE
Perms refusal and logging cleanup

### DIFF
--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -85,7 +85,7 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
         seen = set()
 
         for tag_name in tag_names:
-            cleaned = " ".join((tag_name or "").strip().replace("#","").split())
+            cleaned = " ".join((tag_name or "").strip().replace("#", "").split())
             canonical = Tag.normalize_name(cleaned)
             if not canonical or canonical in seen:
                 continue
@@ -613,8 +613,11 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
 
             # If there was a refusal, return a message
             if len(refusals) > 0:
-                # TODO: evaluate logger level and details of `refusals`
-                logger.error(refusals)
+                logger.warning(
+                    "Perms updates requested by user %s refused for users: %s",
+                    requester.id,
+                    [user.id for user in refusals],
+                )
                 raise MsgFailure(
                     msg=f"Could not update {len(refusals)} out of {len(updates)} permissions."
                 )

--- a/src/components/my-widgets-collaborate-dialog.jsx
+++ b/src/components/my-widgets-collaborate-dialog.jsx
@@ -64,10 +64,7 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 
 	useEffect(() => {
 		if (userList.error) {
-			setError(`User search failed with error: ${data.msg}`);
-			if (userList.error.title == "Invalid Login") {
-				setInvalidLogin(true)
-			}
+			setError(`User search failed with error: ${data.msg}`)
 		}
 	}, [userList.error])
 
@@ -205,15 +202,7 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 				}
 			},
 			errorFunc: (err) => {
-				if (err.message == "Share Not Allowed")
-				{
-					setState({...state, shareNotAllowed: true})
-				} else if (err.message == "Invalid Login")
-				{
-					setInvalidLogin(true)
-				} else {
-					setError((err.message || "Error") + ": Failed to save permissions.")
-				}
+				setError(err.message || "Failed to save permissions.")
 			}
 		})
 


### PR DESCRIPTION
Minor tweaks to resolve #1816:

- Replaced `logger.error()` with `logger.warning()`. Improved perms refusals warning message.
- Cleaned up error handling in collab dialog.