### PR TITLE
Implement POST message OIDC authentication

### DIFF
--- a/app/lti/templates/lti.json
+++ b/app/lti/templates/lti.json
@@ -17,7 +17,11 @@
               "display_type": "in_nav_context",
               "placement": "course_navigation",
               "message_type": "LtiResourceLinkRequest",
-              "target_link_uri": "{{ app_hostname }}/ltilaunch/"
+              "target_link_uri": "{{ app_hostname }}/ltilaunch/",
+              "custom_fields": {
+                "start_time": "$ResourceLink.avaliable.startDateTime",
+                "end_time": "$ResourceLink.avaliable.endDateTime"
+              }
             },
             {
               "text":"Materia Widget",
@@ -26,7 +30,11 @@
               "selection_width":"800",
               "selection_height":"600",
               "message_type":"LtiDeepLinkingRequest",
-              "target_link_uri": "{{ app_hostname }}/ltilaunch/"
+              "target_link_uri": "{{ app_hostname }}/ltilaunch/",
+              "custom_fields": {
+                "start_time": "$ResourceLink.avaliable.startDateTime",
+                "end_time": "$ResourceLink.avaliable.endDateTime"
+              }
             },
             {
               "text":"Materia Widget",
@@ -35,7 +43,11 @@
               "selection_width":"600",
               "selection_height":"400",
               "message_type":"LtiDeepLinkingRequest",
-              "target_link_uri": "{{ app_hostname }}/ltilaunch/"
+              "target_link_uri": "{{ app_hostname }}/ltilaunch/",
+              "custom_fields": {
+                "start_time": "$ResourceLink.avaliable.startDateTime",
+                "end_time": "$ResourceLink.avaliable.endDateTime"
+              }
             }
           ]
         },

--- a/app/lti/templates/oidc_get.html
+++ b/app/lti/templates/oidc_get.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8"/>
         <meta name="viewport" content="width=device-width" />
-        <title>LTI OIDC Auth</title>
+        <title>LTI OIDC Auth - Get</title>
         <style>
             p {
                 font-family: Arial, Helvetica, sans-serif;
@@ -22,10 +22,9 @@
                 const nonceKey = readValue('nonce_key')
                 const frameName = readValue('storage_target')
                 const platformOrigin = readValue('platform_origin')
-                const parentWindow = window.parent !== window ? window.parent : window.opener
-                const targetFrame = frameName === '_parent'
-                    ? parentWindow
-                    : parentWindow && parentWindow.frames[frameName]
+
+                const parent = window.parent || window.opener;
+                const targetFrame = frameName === "_parent" ? parent : parent.frames[frameName];
                 const status = document.getElementById('status')
 
                 if (!targetFrame) {
@@ -37,21 +36,17 @@
                 const timeoutMilliseconds = 10000
 
                 window.addEventListener('message', event => {
-                    if (
-                        typeof event.data !== 'object' ||
-                        event.data === null ||
-                        event.data.subject !== 'lti.get_data.response' ||
-                        event.origin !== platformOrigin ||
-                        event.source !== targetFrame
-                    ) {
-                        return
-                    }
+                    if (typeof event.data !== "object") return
+                    if (event.data.subject !== "lti.get_data.response") return
+                    if (event.data.message_id !== messageId) return
+                    if (event.origin !== platformOrigin) returns
+                    if (event.source !== targetFrame) return
 
+                    // ensure that the request has been made and saved
                     const pending = requests.get(event.data.message_id)
-                    if (!pending || event.data.key !== pending.key) {
-                        return
-                    }
+                    if (!pending || event.data.key !== pending.key) return
 
+                    // cancel LMS timeout hook
                     clearTimeout(pending.timeout)
                     requests.delete(event.data.message_id)
                     if (event.data.error) {
@@ -59,22 +54,29 @@
                         return
                     }
 
+                    // make sure we get a proper state/nonce value back
                     if (typeof event.data.value !== 'string') {
                         pending.reject(new Error('The LMS returned an invalid storage value'))
                         return
                     }
 
+                    // resolve get_data promise with the returned data from LMS
                     pending.resolve(event.data.value)
                 })
 
+                // sends a get_data request to the LMS
+                // returns a promise that is resolved by the message event
                 const getData = key => new Promise((resolve, reject) => {
                     const messageId = self.crypto.randomUUID()
+                    // handle LMS response timeout
                     const timeout = setTimeout(() => {
                         requests.delete(messageId)
                         reject(new Error('The LMS storage request timed out'))
                     }, timeoutMilliseconds)
 
+                    // store the request promise parameters
                     requests.set(messageId, {key, resolve, reject, timeout})
+                    // post message to LMS
                     targetFrame.postMessage({
                         subject: 'lti.get_data',
                         message_id: messageId,
@@ -82,8 +84,13 @@
                     }, platformOrigin)
                 })
 
-                Promise.all([getData(stateKey), getData(nonceKey)])
-                    .then(([platformState, platformNonce]) => {
+                // create POST get_data requests for state and nonce
+                // catch then upon being resolved
+                Promise.all([ getData(stateKey), getData(nonceKey) ])
+                    .then(([ platformState, platformNonce ]) => {
+                        // prepare completion message, send back to tool
+                        // uses a form to send data back to the /ltilaunch endpoint* 
+                        // *or whatever endpoint sent us here
                         document.getElementById('handoff_input').value = handoffId
                         document.getElementById('state_input').value = platformState
                         document.getElementById('nonce_input').value = platformNonce
@@ -96,10 +103,13 @@
         </script>
     </head>
     <body>
-        <p id="status">Validating your LMS launch. Please wait...</p>
+        <p id="status">Validating the request with your LMS. Please wait...</p>
         <form id="validation_form" method="post">
+            <!-- tell launch endpoint that we have retrieved state/nonce from the LMS -->
             <input type="hidden" name="oidc_storage_complete" value="1" />
+            <!-- route tool to validate using message storage rather than cookies-->
             <input type="hidden" name="lti_storage_target" value="{{ storage_target }}" />
+            <!-- track specific validation request -->
             <input id="handoff_input" type="hidden" name="handoff_id" />
             <input id="state_input" type="hidden" name="platform_state" />
             <input id="nonce_input" type="hidden" name="platform_nonce" />

--- a/app/lti/templates/oidc_get.html
+++ b/app/lti/templates/oidc_get.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8"/>
+        <meta name="viewport" content="width=device-width" />
+        <title>LTI OIDC Auth</title>
+        <style>
+            p {
+                font-family: Arial, Helvetica, sans-serif;
+            }
+        </style>
+        {{ handoff_id|json_script:"handoff_id" }}
+        {{ state_key|json_script:"state_key" }}
+        {{ nonce_key|json_script:"nonce_key" }}
+        {{ storage_target|json_script:"storage_target" }}
+        {{ platform_origin|json_script:"platform_origin" }}
+        <script>
+            window.addEventListener('load', () => {
+                const readValue = id => JSON.parse(document.getElementById(id).textContent)
+                const handoffId = readValue('handoff_id')
+                const stateKey = readValue('state_key')
+                const nonceKey = readValue('nonce_key')
+                const frameName = readValue('storage_target')
+                const platformOrigin = readValue('platform_origin')
+                const parentWindow = window.parent !== window ? window.parent : window.opener
+                const targetFrame = frameName === '_parent'
+                    ? parentWindow
+                    : parentWindow && parentWindow.frames[frameName]
+                const status = document.getElementById('status')
+
+                if (!targetFrame) {
+                    status.textContent = 'There was an issue locating the LMS storage frame.'
+                    return
+                }
+
+                const requests = new Map()
+                const timeoutMilliseconds = 10000
+
+                window.addEventListener('message', event => {
+                    if (
+                        typeof event.data !== 'object' ||
+                        event.data === null ||
+                        event.data.subject !== 'lti.get_data.response' ||
+                        event.origin !== platformOrigin ||
+                        event.source !== targetFrame
+                    ) {
+                        return
+                    }
+
+                    const pending = requests.get(event.data.message_id)
+                    if (!pending || event.data.key !== pending.key) {
+                        return
+                    }
+
+                    clearTimeout(pending.timeout)
+                    requests.delete(event.data.message_id)
+                    if (event.data.error) {
+                        pending.reject(new Error(event.data.error.message || 'LMS storage error'))
+                        return
+                    }
+
+                    if (typeof event.data.value !== 'string') {
+                        pending.reject(new Error('The LMS returned an invalid storage value'))
+                        return
+                    }
+
+                    pending.resolve(event.data.value)
+                })
+
+                const getData = key => new Promise((resolve, reject) => {
+                    const messageId = self.crypto.randomUUID()
+                    const timeout = setTimeout(() => {
+                        requests.delete(messageId)
+                        reject(new Error('The LMS storage request timed out'))
+                    }, timeoutMilliseconds)
+
+                    requests.set(messageId, {key, resolve, reject, timeout})
+                    targetFrame.postMessage({
+                        subject: 'lti.get_data',
+                        message_id: messageId,
+                        key,
+                    }, platformOrigin)
+                })
+
+                Promise.all([getData(stateKey), getData(nonceKey)])
+                    .then(([platformState, platformNonce]) => {
+                        document.getElementById('handoff_input').value = handoffId
+                        document.getElementById('state_input').value = platformState
+                        document.getElementById('nonce_input').value = platformNonce
+                        document.getElementById('validation_form').submit()
+                    })
+                    .catch(error => {
+                        status.textContent = error.message
+                    })
+            })
+        </script>
+    </head>
+    <body>
+        <p id="status">Validating your LMS launch. Please wait...</p>
+        <form id="validation_form" method="post">
+            <input type="hidden" name="oidc_storage_complete" value="1" />
+            <input type="hidden" name="lti_storage_target" value="{{ storage_target }}" />
+            <input id="handoff_input" type="hidden" name="handoff_id" />
+            <input id="state_input" type="hidden" name="platform_state" />
+            <input id="nonce_input" type="hidden" name="platform_nonce" />
+        </form>
+    </body>
+</html>

--- a/app/lti/templates/oidc_get.html
+++ b/app/lti/templates/oidc_get.html
@@ -38,7 +38,6 @@
                 window.addEventListener('message', event => {
                     if (typeof event.data !== "object") return
                     if (event.data.subject !== "lti.get_data.response") return
-                    if (event.data.message_id !== messageId) return
                     if (event.origin !== platformOrigin) returns
                     if (event.source !== targetFrame) return
 

--- a/app/lti/templates/oidc_put.html
+++ b/app/lti/templates/oidc_put.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8"/>
+        <meta name="viewport" content="width=device-width" />
+        <title>LTI OIDC Auth</title>
+        <style>
+            p {
+              font-family: Arial, Helvetica, sans-serif;
+            }
+        </style>
+        {{redirect_uri | json_script:"redirect_script"}}
+        {{params | json_script:"params_script"}}
+        <script>
+            window.addEventListener('load', () => {
+                let platformOIDCLoginURL = JSON.parse(document.getElementById('redirect_script').textContent);
+                let urlOBJ = new URL(platformOIDCLoginURL)
+                let platformOrigin = urlOBJ.origin;
+
+                const state = urlOBJ.searchParams.get("state")
+                const nonce = urlOBJ.searchParams.get("nonce")
+
+                if(!state || !nonce) {
+                    document.getElementById("status").innerHTML = "There was an issue verifying your launch."
+                    return
+                }
+
+                const params = JSON.parse(JSON.parse(document.getElementById('params_script').textContent));
+                
+                let frameName = params["lti_storage_target"];
+                let parent = window.parent || window.opener;
+                let targetFrame = frameName === "_parent" ? parent : parent.frames[frameName];
+
+                let messageId = self.crypto.randomUUID();
+
+                window.addEventListener('message', function (event) {
+                    // This isn't a message we're expecting
+                    if (typeof event.data !== "object"){
+                        return;
+                    }
+
+                    // Validate it's the response type you expect
+                    if (event.data.subject !== "lti.put_data.response") {
+                        return;
+                    }
+
+                    // Validate the message id matches the id you sent
+                    if (event.data.message_id !== messageId) {
+                        // this is not the response you're looking for
+                        return;
+                    }
+
+                    // Validate that the event's origin is the same as the derived platform origin
+                    if (event.origin !== platformOrigin) {
+                        return;
+                    }
+
+                    // handle errors
+                    if (event.data.error){
+                        // handle errors
+                        console.log(event.data.error.code)
+                        console.log(event.data.error.message)
+                        return;
+                    }
+
+                    // It's the response we expected
+                    // The state and nonce values were successfully stored, redirect to Platform
+                    window.location.href = urlOBJ.toString()
+                });
+
+                targetFrame.postMessage({
+                    "subject": "lti.put_data",
+                    "message_id": messageId,
+                    "key": state,
+                    "value": state.replace("state_", "")
+                } , platformOrigin )
+    
+    
+                targetFrame.postMessage({
+                    "subject": "lti.put_data",
+                    "message_id": messageId,
+                    "key": nonce,
+                    "value": nonce.replace("nonce_", "")
+                } , platformOrigin )
+            })
+        </script>
+    </head>
+    <body>
+        <p id="status">Authenticating with your LMS. Please wait...</p>
+    </body>
+</html>

--- a/app/lti/templates/oidc_put.html
+++ b/app/lti/templates/oidc_put.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8"/>
         <meta name="viewport" content="width=device-width" />
-        <title>LTI OIDC Auth</title>
+        <title>LTI OIDC Auth - Put</title>
         <style>
             p {
               font-family: Arial, Helvetica, sans-serif;
@@ -34,26 +34,11 @@
                 let messageId = self.crypto.randomUUID();
 
                 window.addEventListener('message', function (event) {
-                    // This isn't a message we're expecting
-                    if (typeof event.data !== "object"){
-                        return;
-                    }
-
-                    // Validate it's the response type you expect
-                    if (event.data.subject !== "lti.put_data.response") {
-                        return;
-                    }
-
-                    // Validate the message id matches the id you sent
-                    if (event.data.message_id !== messageId) {
-                        // this is not the response you're looking for
-                        return;
-                    }
-
-                    // Validate that the event's origin is the same as the derived platform origin
-                    if (event.origin !== platformOrigin) {
-                        return;
-                    }
+                    if (typeof event.data !== "object") return
+                    if (event.data.subject !== "lti.put_data.response") return
+                    if (event.data.message_id !== messageId) return
+                    if (event.origin !== platformOrigin) returns
+                    if (event.source !== targetFrame) return
 
                     // handle errors
                     if (event.data.error){

--- a/app/lti/utils.py
+++ b/app/lti/utils.py
@@ -1,0 +1,53 @@
+from typing import Optional
+
+from django.http.request import HttpRequest
+from pylti1p3.exception import LtiException
+
+from pylti1p3.contrib.django.message_launch import DjangoMessageLaunch
+from pylti1p3.contrib.django.launch_data_storage.cache import DjangoCacheDataStorage
+from pylti1p3.contrib.django.message_launch import DjangoMessageLaunch
+
+from lti_tool.views import DjangoToolConfig
+from lti_tool.models import (
+    LtiLaunch,
+)
+
+
+def get_launch_from_request(
+    request: HttpRequest, launch_id: Optional[str] = None
+) -> LtiLaunch:
+    """Returns the DjangoMessageLaunch associated with a request.
+
+    Optionally, a launch_id may be specified to retrieve the launch from the cache.
+    """
+    tool_conf = DjangoToolConfig()
+    launch_data_storage = DjangoCacheDataStorage()
+    if launch_id is not None:
+        message_launch = MateriaMessageLaunch.from_cache(
+            launch_id, request, tool_conf, launch_data_storage=launch_data_storage
+        )
+    else:
+        message_launch = MateriaMessageLaunch(
+            request, tool_conf, launch_data_storage=launch_data_storage
+        )
+        message_launch.validate()
+    return LtiLaunch(message_launch)
+
+class MateriaMessageLaunch(DjangoMessageLaunch):
+
+    def validate_state(self) -> "MateriaMessageLaunch":
+        state_from_request = self._get_request_param("state")
+        if not state_from_request:
+            raise LtiException("Missing state param")
+
+        id_token_hash = self._get_id_token_hash()
+        if not self._session_service.check_state_is_valid(
+            state_from_request, id_token_hash
+        ):
+            # state_from_cookie = self._cookie_service.get_cookie(state_from_request)
+            # if state_from_request != state_from_cookie:
+            #     # Error if state doesn't match.
+            #     raise LtiException("State not found")
+            pass
+
+        return self

--- a/app/lti/utils.py
+++ b/app/lti/utils.py
@@ -51,24 +51,17 @@ def store_post_message_initiation(
     )
 
 
-def claim_post_message_initiation(state: str, storage_target: str) -> dict:
+def consume_post_message_initiation(state: str, storage_target: str) -> dict:
     """Claim an initiation exactly once before rendering the get_data bridge."""
 
     initiation = cache.get(_get_cache_key("initiation", state))
     if not initiation:
-        raise LtiException("Post-message OIDC initiation not found or expired")
+        raise LtiException("Post-message OIDC initiation expired or was consumed")
 
     if initiation.get("storage_target") != storage_target:
         raise LtiException("Post-message OIDC storage target does not match")
 
-    claimed = cache.add(
-        _get_cache_key("initiation-claimed", state),
-        True,
-        timeout=_get_post_message_timeout(),
-    )
-    if not claimed:
-        raise LtiException("Post-message OIDC initiation has already been used")
-
+    cache.delete(_get_cache_key("initiation", state))
     return initiation
 
 
@@ -92,53 +85,20 @@ def consume_post_message_handoff(handoff_id: str, storage_target: str) -> dict:
 
     handoff = cache.get(_get_cache_key("handoff", handoff_id))
     if not handoff:
-        raise LtiException("Post-message OIDC handoff not found or expired")
+        raise LtiException("Post-message OIDC handoff expired or was consumed")
 
     if handoff.get("storage_target") != storage_target:
         raise LtiException("Post-message OIDC storage target does not match")
 
-    consumed = cache.add(
-        _get_cache_key("handoff-consumed", handoff_id),
-        True,
-        timeout=_get_post_message_timeout(),
-    )
-    if not consumed:
-        raise LtiException("Post-message OIDC handoff has already been used")
-
     cache.delete(_get_cache_key("handoff", handoff_id))
-    cache.delete(_get_cache_key("initiation", handoff["state"]))
     return handoff
-
-
-def validate_post_message_values(
-    handoff: dict, platform_state: str, platform_nonce: str
-) -> None:
-    """Compare the values returned by the platform with the initiation values."""
-
-    expected_state = handoff.get("state")
-    expected_nonce = handoff.get("nonce")
-    if not all(
-        isinstance(value, str)
-        for value in (
-            expected_state,
-            expected_nonce,
-            platform_state,
-            platform_nonce,
-        )
-    ):
-        raise LtiException("Post-message OIDC state or nonce is missing")
-
-    if not secrets.compare_digest(expected_state, platform_state):
-        raise LtiException("Post-message OIDC state does not match")
-
-    if not secrets.compare_digest(expected_nonce, platform_nonce):
-        raise LtiException("Post-message OIDC nonce does not match")
 
 
 def get_launch_from_request(
     request: HttpRequest, launch_id: Optional[str] = None
 ) -> LtiLaunch:
-    """Returns the DjangoMessageLaunch associated with a request.
+    """Returns the MateriaMessageLaunch associated with a request.
+    Based on the Django LTI implementation, altered to use our override message launch
 
     Optionally, a launch_id may be specified to retrieve the launch from the cache.
     """
@@ -181,4 +141,4 @@ class MateriaMessageLaunch(DjangoMessageLaunch):
         if not secrets.compare_digest(nonce_from_token, nonce_from_platform):
             raise LtiException("Post-message OIDC nonce does not match")
 
-        return super().validate_nonce()
+        return self

--- a/app/lti/utils.py
+++ b/app/lti/utils.py
@@ -1,16 +1,138 @@
+import secrets
+import uuid
 from typing import Optional
 
+from django.conf import settings
+from django.core.cache import cache
 from django.http.request import HttpRequest
 from pylti1p3.exception import LtiException
-
-from pylti1p3.contrib.django.message_launch import DjangoMessageLaunch
 from pylti1p3.contrib.django.launch_data_storage.cache import DjangoCacheDataStorage
 from pylti1p3.contrib.django.message_launch import DjangoMessageLaunch
 
-from lti_tool.views import DjangoToolConfig
-from lti_tool.models import (
-    LtiLaunch,
-)
+from lti_tool.models import LtiLaunch
+from lti_tool.utils import DjangoToolConfig
+
+
+POST_MESSAGE_CACHE_PREFIX = "lti-oidc-post-message"
+
+
+def _get_post_message_timeout() -> int:
+    return getattr(settings, "LTI_OIDC_POST_MESSAGE_TIMEOUT", 300)
+
+
+def _get_cache_key(value_type: str, value: str) -> str:
+    return f"{POST_MESSAGE_CACHE_PREFIX}:{value_type}:{value}"
+
+
+class CookieFreeDjangoCacheDataStorage(DjangoCacheDataStorage):
+    """Store PyLTI launch data without namespacing it with a browser cookie."""
+
+    def get_session_cookie_name(self) -> Optional[str]:
+        return None
+
+
+def store_post_message_initiation(
+    state: str,
+    nonce: str,
+    storage_target: str,
+    platform_origin: str,
+) -> None:
+    """Remember the browser-storage values needed when the LMS posts back."""
+
+    cache.set(
+        _get_cache_key("initiation", state),
+        {
+            "state": state,
+            "nonce": nonce,
+            "storage_target": storage_target,
+            "platform_origin": platform_origin,
+        },
+        timeout=_get_post_message_timeout(),
+    )
+
+
+def claim_post_message_initiation(state: str, storage_target: str) -> dict:
+    """Claim an initiation exactly once before rendering the get_data bridge."""
+
+    initiation = cache.get(_get_cache_key("initiation", state))
+    if not initiation:
+        raise LtiException("Post-message OIDC initiation not found or expired")
+
+    if initiation.get("storage_target") != storage_target:
+        raise LtiException("Post-message OIDC storage target does not match")
+
+    claimed = cache.add(
+        _get_cache_key("initiation-claimed", state),
+        True,
+        timeout=_get_post_message_timeout(),
+    )
+    if not claimed:
+        raise LtiException("Post-message OIDC initiation has already been used")
+
+    return initiation
+
+
+def create_post_message_handoff(initiation: dict, id_token: str) -> str:
+    """Temporarily retain the LMS response while browser storage is queried."""
+
+    handoff_id = uuid.uuid4().hex
+    cache.set(
+        _get_cache_key("handoff", handoff_id),
+        {
+            **initiation,
+            "id_token": id_token,
+        },
+        timeout=_get_post_message_timeout(),
+    )
+    return handoff_id
+
+
+def consume_post_message_handoff(handoff_id: str, storage_target: str) -> dict:
+    """Retrieve a handoff once and reject expired, mismatched, or replayed IDs."""
+
+    handoff = cache.get(_get_cache_key("handoff", handoff_id))
+    if not handoff:
+        raise LtiException("Post-message OIDC handoff not found or expired")
+
+    if handoff.get("storage_target") != storage_target:
+        raise LtiException("Post-message OIDC storage target does not match")
+
+    consumed = cache.add(
+        _get_cache_key("handoff-consumed", handoff_id),
+        True,
+        timeout=_get_post_message_timeout(),
+    )
+    if not consumed:
+        raise LtiException("Post-message OIDC handoff has already been used")
+
+    cache.delete(_get_cache_key("handoff", handoff_id))
+    cache.delete(_get_cache_key("initiation", handoff["state"]))
+    return handoff
+
+
+def validate_post_message_values(
+    handoff: dict, platform_state: str, platform_nonce: str
+) -> None:
+    """Compare the values returned by the platform with the initiation values."""
+
+    expected_state = handoff.get("state")
+    expected_nonce = handoff.get("nonce")
+    if not all(
+        isinstance(value, str)
+        for value in (
+            expected_state,
+            expected_nonce,
+            platform_state,
+            platform_nonce,
+        )
+    ):
+        raise LtiException("Post-message OIDC state or nonce is missing")
+
+    if not secrets.compare_digest(expected_state, platform_state):
+        raise LtiException("Post-message OIDC state does not match")
+
+    if not secrets.compare_digest(expected_nonce, platform_nonce):
+        raise LtiException("Post-message OIDC nonce does not match")
 
 
 def get_launch_from_request(
@@ -21,7 +143,7 @@ def get_launch_from_request(
     Optionally, a launch_id may be specified to retrieve the launch from the cache.
     """
     tool_conf = DjangoToolConfig()
-    launch_data_storage = DjangoCacheDataStorage()
+    launch_data_storage = CookieFreeDjangoCacheDataStorage()
     if launch_id is not None:
         message_launch = MateriaMessageLaunch.from_cache(
             launch_id, request, tool_conf, launch_data_storage=launch_data_storage
@@ -33,21 +155,30 @@ def get_launch_from_request(
         message_launch.validate()
     return LtiLaunch(message_launch)
 
+
 class MateriaMessageLaunch(DjangoMessageLaunch):
+    """Validate OIDC state and nonce values returned by platform storage."""
 
     def validate_state(self) -> "MateriaMessageLaunch":
         state_from_request = self._get_request_param("state")
-        if not state_from_request:
-            raise LtiException("Missing state param")
+        state_from_platform = self._get_request_param("platform_state")
+        if not state_from_request or not state_from_platform:
+            raise LtiException("Missing post-message OIDC state")
 
-        id_token_hash = self._get_id_token_hash()
-        if not self._session_service.check_state_is_valid(
-            state_from_request, id_token_hash
-        ):
-            # state_from_cookie = self._cookie_service.get_cookie(state_from_request)
-            # if state_from_request != state_from_cookie:
-            #     # Error if state doesn't match.
-            #     raise LtiException("State not found")
-            pass
+        if not secrets.compare_digest(state_from_request, state_from_platform):
+            raise LtiException("Post-message OIDC state does not match")
 
         return self
+
+    def validate_nonce(self) -> "MateriaMessageLaunch":
+        nonce_from_token = self._get_jwt_body().get("nonce")
+        nonce_from_platform = self._get_request_param("platform_nonce")
+        if not isinstance(nonce_from_token, str) or not isinstance(
+            nonce_from_platform, str
+        ):
+            raise LtiException("Missing post-message OIDC nonce")
+
+        if not secrets.compare_digest(nonce_from_token, nonce_from_platform):
+            raise LtiException("Post-message OIDC nonce does not match")
+
+        return super().validate_nonce()

--- a/app/lti/views/init.py
+++ b/app/lti/views/init.py
@@ -1,9 +1,17 @@
 import logging
+import json
 
 from django.conf import settings
-from lti_tool.views import OIDCLoginInitView
+from lti_tool.views import OIDCLoginInitView, DjangoToolConfig, get_launch_from_request
 from pylti1p3.exception import OIDCException
 
+from django.http import (
+    HttpResponseBadRequest,
+)
+
+from django.shortcuts import render
+
+from pylti1p3.contrib.django import DjangoCacheDataStorage, DjangoOIDCLogin
 logger = logging.getLogger(__name__)
 
 
@@ -14,6 +22,7 @@ class MateriaOIDCLoginInitView(OIDCLoginInitView):
         Overrides OIDCLoginInitView's `get` method to intercept and handle OIDCExceptions.
         The intended behavior is to handle situations where a LTI registration has been disabled.
         """
+        print(request)
         registration_uuid = kwargs.get("registration_uuid")
         try:
             return self.get_oidc_response(request, registration_uuid, request.GET)
@@ -31,3 +40,29 @@ class MateriaOIDCLoginInitView(OIDCLoginInitView):
         """
         redirect = f"{settings.URLS["BASE_URL"]}ltilaunch/"
         return redirect
+
+    def get_oidc_response(self, request, registration_uuid, params):
+        if params.get('lti_storage_target', None) == 'post_message_forwarding':
+            tool_conf = DjangoToolConfig(registration_uuid)
+            launch_data_storage = DjangoCacheDataStorage()
+            oidc_login = DjangoOIDCLogin(
+                request, tool_conf, launch_data_storage=launch_data_storage
+            )
+
+            target_link_uri = params.get("target_link_uri")
+            if target_link_uri is None:
+                return HttpResponseBadRequest("Missing target_link_uri parameter.")
+
+            redirect_uri = oidc_login._prepare_redirect_url(target_link_uri)
+            print(redirect_uri)
+
+            return render(
+                request, 
+                "oidc_put.html", 
+                {
+                    "params": json.dumps(params),
+                    "redirect_uri": redirect_uri
+                }
+            )
+    
+        return super().get_oidc_response(request, registration_uuid, params)

--- a/app/lti/views/init.py
+++ b/app/lti/views/init.py
@@ -44,48 +44,50 @@ class MateriaOIDCLoginInitView(OIDCLoginInitView):
 
     def get_oidc_response(self, request, registration_uuid, params):
         storage_target = params.get("lti_storage_target")
-        if storage_target == "post_message_forwarding":
-            tool_conf = DjangoToolConfig(registration_uuid)
-            launch_data_storage = CookieFreeDjangoCacheDataStorage()
-            oidc_login = DjangoOIDCLogin(
-                request, tool_conf, launch_data_storage=launch_data_storage
-            )
+        if storage_target != "post_message_forwarding":
+            return super().get_oidc_response(request, registration_uuid, params)
+        
+        tool_conf = DjangoToolConfig(registration_uuid)
+        launch_data_storage = CookieFreeDjangoCacheDataStorage()
+        oidc_login = DjangoOIDCLogin(
+            request, tool_conf, launch_data_storage=launch_data_storage
+        )
 
-            target_link_uri = params.get("target_link_uri")
-            if target_link_uri is None:
-                return HttpResponseBadRequest("Missing target_link_uri parameter.")
+        target_link_uri = params.get("target_link_uri")
+        if target_link_uri is None:
+            return HttpResponseBadRequest("Missing target_link_uri parameter.")
 
-            authorization_url = oidc_login.get_redirect_object(
-                target_link_uri
-            ).get_redirect_url()
-            parsed_redirect = urlparse(authorization_url)
-            authorization_params = parse_qs(parsed_redirect.query)
-            state = authorization_params.get("state", [None])[0]
-            nonce = authorization_params.get("nonce", [None])[0]
-            if not state or not nonce:
-                raise OIDCException("OIDC authorization URL is missing state or nonce")
+        authorization_url = oidc_login.get_redirect_object(
+            target_link_uri
+        ).get_redirect_url()
+        parsed_redirect = urlparse(authorization_url)
+        authorization_params = parse_qs(parsed_redirect.query)
+        state = authorization_params.get("state", [None])[0]
+        nonce = authorization_params.get("nonce", [None])[0]
+        if not state or not nonce:
+            raise OIDCException("OIDC authorization URL is missing state or nonce")
 
-            if (
-                parsed_redirect.scheme not in ("http", "https")
-                or not parsed_redirect.netloc
-            ):
-                raise OIDCException("OIDC authorization URL has an invalid origin")
+        if (
+            parsed_redirect.scheme not in ("http", "https")
+            or not parsed_redirect.netloc
+        ):
+            raise OIDCException("OIDC authorization URL has an invalid origin")
 
-            platform_origin = f"{parsed_redirect.scheme}://{parsed_redirect.netloc}"
-            store_post_message_initiation(
-                state,
-                nonce,
-                storage_target,
-                platform_origin,
-            )
+        platform_origin = f"{parsed_redirect.scheme}://{parsed_redirect.netloc}"
+        store_post_message_initiation(
+            state,
+            nonce,
+            storage_target,
+            platform_origin,
+        )
 
-            return render(
-                request,
-                "oidc_put.html",
-                {
-                    "params": json.dumps(params),
-                    "redirect_uri": authorization_url,
-                },
-            )
+        print("NONCE:", nonce)
 
-        return super().get_oidc_response(request, registration_uuid, params)
+        return render(
+            request,
+            "oidc_put.html",
+            {
+                "params": json.dumps(params),
+                "redirect_uri": authorization_url,
+            },
+        )

--- a/app/lti/views/init.py
+++ b/app/lti/views/init.py
@@ -1,17 +1,19 @@
-import logging
 import json
+import logging
+from urllib.parse import parse_qs, urlparse
 
 from django.conf import settings
-from lti_tool.views import OIDCLoginInitView, DjangoToolConfig, get_launch_from_request
+from django.http import HttpResponseBadRequest
+from django.shortcuts import render
+from lti.utils import (
+    CookieFreeDjangoCacheDataStorage,
+    store_post_message_initiation,
+)
+from lti_tool.utils import DjangoToolConfig
+from lti_tool.views import OIDCLoginInitView
+from pylti1p3.contrib.django import DjangoOIDCLogin
 from pylti1p3.exception import OIDCException
 
-from django.http import (
-    HttpResponseBadRequest,
-)
-
-from django.shortcuts import render
-
-from pylti1p3.contrib.django import DjangoCacheDataStorage, DjangoOIDCLogin
 logger = logging.getLogger(__name__)
 
 
@@ -22,7 +24,6 @@ class MateriaOIDCLoginInitView(OIDCLoginInitView):
         Overrides OIDCLoginInitView's `get` method to intercept and handle OIDCExceptions.
         The intended behavior is to handle situations where a LTI registration has been disabled.
         """
-        print(request)
         registration_uuid = kwargs.get("registration_uuid")
         try:
             return self.get_oidc_response(request, registration_uuid, request.GET)
@@ -42,9 +43,10 @@ class MateriaOIDCLoginInitView(OIDCLoginInitView):
         return redirect
 
     def get_oidc_response(self, request, registration_uuid, params):
-        if params.get('lti_storage_target', None) == 'post_message_forwarding':
+        storage_target = params.get("lti_storage_target")
+        if storage_target == "post_message_forwarding":
             tool_conf = DjangoToolConfig(registration_uuid)
-            launch_data_storage = DjangoCacheDataStorage()
+            launch_data_storage = CookieFreeDjangoCacheDataStorage()
             oidc_login = DjangoOIDCLogin(
                 request, tool_conf, launch_data_storage=launch_data_storage
             )
@@ -53,16 +55,37 @@ class MateriaOIDCLoginInitView(OIDCLoginInitView):
             if target_link_uri is None:
                 return HttpResponseBadRequest("Missing target_link_uri parameter.")
 
-            redirect_uri = oidc_login._prepare_redirect_url(target_link_uri)
-            print(redirect_uri)
+            authorization_url = oidc_login.get_redirect_object(
+                target_link_uri
+            ).get_redirect_url()
+            parsed_redirect = urlparse(authorization_url)
+            authorization_params = parse_qs(parsed_redirect.query)
+            state = authorization_params.get("state", [None])[0]
+            nonce = authorization_params.get("nonce", [None])[0]
+            if not state or not nonce:
+                raise OIDCException("OIDC authorization URL is missing state or nonce")
+
+            if (
+                parsed_redirect.scheme not in ("http", "https")
+                or not parsed_redirect.netloc
+            ):
+                raise OIDCException("OIDC authorization URL has an invalid origin")
+
+            platform_origin = f"{parsed_redirect.scheme}://{parsed_redirect.netloc}"
+            store_post_message_initiation(
+                state,
+                nonce,
+                storage_target,
+                platform_origin,
+            )
 
             return render(
-                request, 
-                "oidc_put.html", 
+                request,
+                "oidc_put.html",
                 {
                     "params": json.dumps(params),
-                    "redirect_uri": redirect_uri
-                }
+                    "redirect_uri": authorization_url,
+                },
             )
-    
+
         return super().get_oidc_response(request, registration_uuid, params)

--- a/app/lti/views/launch.py
+++ b/app/lti/views/launch.py
@@ -1,17 +1,22 @@
 import logging
 
-from django.shortcuts import redirect
+from django.shortcuts import redirect, render
 from lti.exceptions import LTIAuthException
 from lti.services.auth import LTIAuthService
 from lti.services.launch import LTILaunchService
+from lti.utils import (
+    claim_post_message_initiation,
+    consume_post_message_handoff,
+    create_post_message_handoff,
+    get_launch_from_request,
+    validate_post_message_values,
+)
 from lti.views.lti import error_page
-from lti_tool.types import LtiHttpRequest
-from lti_tool.views import LtiLaunchBaseView
-from lti_tool.utils import sync_data_from_launch
 from lti_tool.constants import SESSION_KEY
+from lti_tool.types import LtiHttpRequest
+from lti_tool.utils import sync_data_from_launch
+from lti_tool.views import LtiLaunchBaseView
 from pylti1p3.exception import LtiException
-
-from lti.utils import get_launch_from_request
 
 logger = logging.getLogger(__name__)
 
@@ -23,28 +28,72 @@ class ApplicationLaunchView(LtiLaunchBaseView):
         Overrides django-lti's post method in order to intercept validation exceptions
         """
         try:
-            if request.POST.get('lti_storage_target', None) != 'post_message_forwarding':
+            storage_target = request.POST.get("lti_storage_target")
+            if storage_target != "post_message_forwarding":
                 return super().post(request, *args, **kwargs)
+
+            if request.POST.get("oidc_storage_complete") != "1":
+                return self.prepare_post_message_validation(request, storage_target)
+
+            handoff = consume_post_message_handoff(
+                request.POST.get("handoff_id", ""), storage_target
+            )
+            platform_state = request.POST.get("platform_state", "")
+            platform_nonce = request.POST.get("platform_nonce", "")
+            validate_post_message_values(handoff, platform_state, platform_nonce)
+
+            launch_post = request.POST.copy()
+            launch_post["state"] = handoff["state"]
+            launch_post["id_token"] = handoff["id_token"]
+            launch_post["platform_state"] = platform_state
+            launch_post["platform_nonce"] = platform_nonce
+            request.POST = launch_post
 
             request.session.clear()
             lti_launch = get_launch_from_request(request)
-            sync_data_from_launch(lti_launch)
-            self.launch_setup(request, lti_launch)
-            if not lti_launch.deployment.is_active:
-                return self.handle_inactive_deployment(request, lti_launch)
-            request.session[SESSION_KEY] = lti_launch.get_launch_id()
-            request.lti_launch = lti_launch
-            if request.lti_launch.is_resource_launch:
-                return self.handle_resource_launch(request, lti_launch)
-            if request.lti_launch.is_deep_link_launch:
-                return self.handle_deep_linking_launch(request, lti_launch)
-            if request.lti_launch.is_submission_review_launch:
-                return self.handle_submission_review_launch(request, lti_launch)
-            if request.lti_launch.is_data_privacy_launch:
-                return self.handle_data_privacy_launch(request, lti_launch)
+            return self.process_validated_launch(request, lti_launch)
         except LtiException:
-            logger.error(f"LTI: Launch validation failed", exc_info=True)
+            logger.error("LTI: Launch validation failed", exc_info=True)
             return error_page(request, "error_launch_validation")
+
+    def prepare_post_message_validation(self, request, storage_target):
+        state = request.POST.get("state")
+        id_token = request.POST.get("id_token")
+        if not state or not id_token:
+            raise LtiException("Missing state or id_token")
+
+        initiation = claim_post_message_initiation(state, storage_target)
+        handoff_id = create_post_message_handoff(initiation, id_token)
+        return render(
+            request,
+            "oidc_get.html",
+            {
+                "handoff_id": handoff_id,
+                "state_key": initiation["state"],
+                "nonce_key": initiation["nonce"],
+                "storage_target": storage_target,
+                "platform_origin": initiation["platform_origin"],
+            },
+        )
+
+    def process_validated_launch(self, request, lti_launch):
+        sync_data_from_launch(lti_launch)
+        self.launch_setup(request, lti_launch)
+        if not lti_launch.deployment.is_active:
+            return self.handle_inactive_deployment(request, lti_launch)
+
+        request.session[SESSION_KEY] = lti_launch.get_launch_id()
+        request.lti_launch = lti_launch
+        if request.lti_launch.is_resource_launch:
+            return self.handle_resource_launch(request, lti_launch)
+        if request.lti_launch.is_deep_link_launch:
+            return self.handle_deep_linking_launch(request, lti_launch)
+        if request.lti_launch.is_submission_review_launch:
+            return self.handle_submission_review_launch(request, lti_launch)
+        if request.lti_launch.is_data_privacy_launch:
+            return self.handle_data_privacy_launch(request, lti_launch)
+
+        raise LtiException("Unsupported LTI launch message type")
 
     def handle_resource_launch(self, request, lti_launch):
         launch_data = lti_launch.get_launch_data()

--- a/app/lti/views/launch.py
+++ b/app/lti/views/launch.py
@@ -5,11 +5,10 @@ from lti.exceptions import LTIAuthException
 from lti.services.auth import LTIAuthService
 from lti.services.launch import LTILaunchService
 from lti.utils import (
-    claim_post_message_initiation,
+    consume_post_message_initiation,
     consume_post_message_handoff,
     create_post_message_handoff,
     get_launch_from_request,
-    validate_post_message_values,
 )
 from lti.views.lti import error_page
 from lti_tool.constants import SESSION_KEY
@@ -30,23 +29,21 @@ class ApplicationLaunchView(LtiLaunchBaseView):
         try:
             storage_target = request.POST.get("lti_storage_target")
             if storage_target != "post_message_forwarding":
+                # launch using cookies if we cant use post messages
                 return super().post(request, *args, **kwargs)
 
+            # if we have not retrieved storage values yet, route to oidc_get template
             if request.POST.get("oidc_storage_complete") != "1":
                 return self.prepare_post_message_validation(request, storage_target)
 
             handoff = consume_post_message_handoff(
                 request.POST.get("handoff_id", ""), storage_target
             )
-            platform_state = request.POST.get("platform_state", "")
-            platform_nonce = request.POST.get("platform_nonce", "")
-            validate_post_message_values(handoff, platform_state, platform_nonce)
 
             launch_post = request.POST.copy()
             launch_post["state"] = handoff["state"]
             launch_post["id_token"] = handoff["id_token"]
-            launch_post["platform_state"] = platform_state
-            launch_post["platform_nonce"] = platform_nonce
+
             request.POST = launch_post
 
             request.session.clear()
@@ -62,7 +59,7 @@ class ApplicationLaunchView(LtiLaunchBaseView):
         if not state or not id_token:
             raise LtiException("Missing state or id_token")
 
-        initiation = claim_post_message_initiation(state, storage_target)
+        initiation = consume_post_message_initiation(state, storage_target)
         handoff_id = create_post_message_handoff(initiation, id_token)
         return render(
             request,

--- a/app/lti/views/launch.py
+++ b/app/lti/views/launch.py
@@ -7,7 +7,11 @@ from lti.services.launch import LTILaunchService
 from lti.views.lti import error_page
 from lti_tool.types import LtiHttpRequest
 from lti_tool.views import LtiLaunchBaseView
+from lti_tool.utils import sync_data_from_launch
+from lti_tool.constants import SESSION_KEY
 from pylti1p3.exception import LtiException
+
+from lti.utils import get_launch_from_request
 
 logger = logging.getLogger(__name__)
 
@@ -19,9 +23,27 @@ class ApplicationLaunchView(LtiLaunchBaseView):
         Overrides django-lti's post method in order to intercept validation exceptions
         """
         try:
-            return super().post(request, *args, **kwargs)
+            if request.POST.get('lti_storage_target', None) != 'post_message_forwarding':
+                return super().post(request, *args, **kwargs)
+
+            request.session.clear()
+            lti_launch = get_launch_from_request(request)
+            sync_data_from_launch(lti_launch)
+            self.launch_setup(request, lti_launch)
+            if not lti_launch.deployment.is_active:
+                return self.handle_inactive_deployment(request, lti_launch)
+            request.session[SESSION_KEY] = lti_launch.get_launch_id()
+            request.lti_launch = lti_launch
+            if request.lti_launch.is_resource_launch:
+                return self.handle_resource_launch(request, lti_launch)
+            if request.lti_launch.is_deep_link_launch:
+                return self.handle_deep_linking_launch(request, lti_launch)
+            if request.lti_launch.is_submission_review_launch:
+                return self.handle_submission_review_launch(request, lti_launch)
+            if request.lti_launch.is_data_privacy_launch:
+                return self.handle_data_privacy_launch(request, lti_launch)
         except LtiException:
-            logger.error("LTI: Launch validation failed", exc_info=True)
+            logger.error(f"LTI: Launch validation failed", exc_info=True)
             return error_page(request, "error_launch_validation")
 
     def handle_resource_launch(self, request, lti_launch):

--- a/app/materia/settings/lti.py
+++ b/app/materia/settings/lti.py
@@ -40,3 +40,7 @@ LTI_SAVE_ASSOCIATIONS = True
 LTI_URL_CONFIGS = {
     "tool_url": os.environ.get("BASE_URL", "").rstrip("/"),
 }
+
+LTI_OIDC_POST_MESSAGE_TIMEOUT = int(
+    os.environ.get("LTI_OIDC_POST_MESSAGE_TIMEOUT", "300")
+)


### PR DESCRIPTION
This PR converts OIDC authentication to utilize LMS POST message storage, rather than cookies.
It overrides many django-lit and pylti1p3 classes and functions to perform verification based on storage values instead, and introduces two intermediary authentication templates that are necessary to get/put data in local storage.

In the event that an LMS does not support POST message storage, Materia falls back to using cookie verification.